### PR TITLE
`idBuilder` now accepts either `number` or `bigint`

### DIFF
--- a/packages/delegation-toolkit/src/caveatBuilder/idBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/idBuilder.ts
@@ -14,21 +14,31 @@ export const id = 'id';
  */
 export function idBuilder(
   environment: DeleGatorEnvironment,
-  idValue: number,
+  idValue: bigint | number,
 ): Caveat {
-  if (!Number.isInteger(idValue)) {
-    throw new Error('Invalid id: must be an integer');
+  let idValueBigInt: bigint;
+
+  if (typeof idValue === 'number') {
+    if (!Number.isInteger(idValue)) {
+      throw new Error('Invalid id: must be an integer');
+    }
+
+    idValueBigInt = BigInt(idValue);
+  } else if (typeof idValue === 'bigint') {
+    idValueBigInt = idValue;
+  } else {
+    throw new Error('Invalid id: must be a bigint or number');
   }
 
-  if (idValue < 0) {
+  if (idValueBigInt < 0n) {
     throw new Error('Invalid id: must be positive');
   }
 
-  if (idValue > maxUint256) {
+  if (idValueBigInt > maxUint256) {
     throw new Error('Invalid id: must be less than 2^256');
   }
 
-  const terms = toHex(idValue, { size: 32 });
+  const terms = toHex(idValueBigInt, { size: 32 });
 
   const {
     caveatEnforcers: { IdEnforcer },

--- a/packages/delegation-toolkit/test/caveatBuilder/createCaveatBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/createCaveatBuilder.test.ts
@@ -238,7 +238,7 @@ describe('createCaveatBuilder()', () => {
     it("should add an 'id' caveat", () => {
       const builder = createCaveatBuilder(environment);
 
-      const id = Math.floor(Math.random() * 2 ** 32);
+      const id = BigInt(Math.floor(Math.random() * 2 ** 32));
       const caveats = builder.addCaveat('id', id).build();
 
       expect(caveats).to.deep.equal([


### PR DESCRIPTION
## 📝 Description

Previous `idBuilder` required the id to be passed as a `number` type, which restricted the id up to `Number.MAX_SAFE_INTEGER`.

With this change, the `idBuilder` now accepts either a `bigint` or `number`:

```
new CaveatBuilder(environment).addCaveat("id", 123n);
new CaveatBuilder(environment).addCaveat("id", 123);
```

## 🧪 How to Test?

This is sufficiently covered in unit tests, validating both number and bigint. The above code snippets can be used to manually validate the behaviour.

## ⚠️ Breaking Changes

List any breaking changes:

- [x] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Tests added/updated
- [x] Changelog updated (if needed)
- [x] All CI checks pass
