### PR TITLE
Fix e2e tests

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -13,6 +13,14 @@ on:
       NPM_CLIENT:
         type: string
         default: 'yarn'
+      RUN_FULL_TESTS:
+        type: boolean
+        default: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') }}
+  workflow_dispatch:
+    inputs:
+      RUN_FULL_TESTS:
+        type: boolean
+        default: true
 
 jobs:
   pipeline:
@@ -53,7 +61,7 @@ jobs:
 
       - name: Run end-to-end tests
         run: |
-          if [[ "$GITHUB_REF" == "refs/heads/main" ]] || [[ "$GITHUB_REF" =~ ^refs/heads/release/ ]]; then
+          if [[ "${{ inputs.RUN_FULL_TESTS }}" == "true" ]]; then
             yarn e2etest:full
           else
             yarn e2etest:smoketest

--- a/packages/delegator-e2e/test/caveats/nativeTokenPayment.test.ts
+++ b/packages/delegator-e2e/test/caveats/nativeTokenPayment.test.ts
@@ -177,13 +177,13 @@ test('Bob attempts to redeem the delegation without providing a valid permission
     ),
   });
 
-  const permissionsContext = '0x';
+  const permissionsContext = '0x' as const;
 
   await runTest_expectFailure(
     delegationRequiringNativeTokenPayment,
     permissionsContext,
     recipient,
-    '', // The NativeTokenPaymentEnforcer rejects when it fails to decode the permissions context
+    undefined, // The NativeTokenPaymentEnforcer rejects when it fails to decode the permissions context
   );
 });
 
@@ -295,15 +295,21 @@ const runTest_expectFailure = async (
   delegation: Delegation,
   permissionsContext: Hex,
   recipient: Address,
-  expectedError: string,
+  expectedError: string | undefined,
 ) => {
   const balanceBefore = await publicClient.getBalance({
     address: recipient,
   });
 
-  await expect(
+  const rejects = expect(
     submitUserOpForTest(delegation, permissionsContext),
-  ).rejects.toThrow(expectedError);
+  ).rejects;
+
+  if (expectedError) {
+    await rejects.toThrow(expectedError);
+  } else {
+    await rejects.toThrow();
+  }
 
   const balanceAfter = await publicClient.getBalance({
     address: recipient,


### PR DESCRIPTION
## 📝 Description

Fix e2e test for payment caveat by expecting a failure, rather than a specific failure (previously expected an empty string, which for some reason was failing 🤷)

Also updates the workflows so that we can manually trigger the e2e test to run the full suite on a branch (which I did to validate the fix).