### PR TITLE
[Deprecated] Improve CaveatBuilders to be less risky

### DIFF
--- a/packages/delegation-core/README.md
+++ b/packages/delegation-core/README.md
@@ -17,6 +17,7 @@ yarn add @metamask/delegation-core
 ## Overview
 
 This package provides utilities for:
+
 - Creating caveat terms for various delegation constraints
 - Encoding and decoding delegations
 - Type definitions for delegation structures
@@ -32,6 +33,7 @@ Caveat terms builders create encoded parameters for different types of delegatio
 Creates terms for a ValueLte caveat that limits the maximum value of native tokens that can be spent.
 
 **Parameters:**
+
 - `terms: ValueLteTerms`
   - `maxValue: bigint` - The maximum value allowed for the transaction
 - `options?: EncodingOptions` - Optional encoding options (`'hex'` | `'bytes'`)
@@ -39,19 +41,23 @@ Creates terms for a ValueLte caveat that limits the maximum value of native toke
 **Returns:** `Hex | Uint8Array` - 32-byte encoded terms
 
 **Example:**
+
 ```typescript
 import { createValueLteTerms } from '@metamask/delegation-core';
 
 // Limit to 1 ETH maximum
 const terms = createValueLteTerms({
-  maxValue: 1000000000000000000n // 1 ETH in wei
+  maxValue: 1000000000000000000n, // 1 ETH in wei
 });
 // Returns: '0x0000000000000000000000000000000000000000000000000de0b6b3a7640000'
 
 // Get as Uint8Array
-const bytesTerms = createValueLteTerms({
-  maxValue: 1000000000000000000n
-}, { out: 'bytes' });
+const bytesTerms = createValueLteTerms(
+  {
+    maxValue: 1000000000000000000n,
+  },
+  { out: 'bytes' },
+);
 ```
 
 #### `createTimestampTerms(terms, options?)`
@@ -59,6 +65,7 @@ const bytesTerms = createValueLteTerms({
 Creates terms for a Timestamp caveat that enforces time-based constraints on delegation usage.
 
 **Parameters:**
+
 - `terms: TimestampTerms`
   - `timestampAfterThreshold: number` - Timestamp (seconds) after which delegation can be used
   - `timestampBeforeThreshold: number` - Timestamp (seconds) before which delegation can be used
@@ -67,19 +74,20 @@ Creates terms for a Timestamp caveat that enforces time-based constraints on del
 **Returns:** `Hex | Uint8Array` - 32-byte encoded terms (16 bytes per timestamp)
 
 **Example:**
+
 ```typescript
 import { createTimestampTerms } from '@metamask/delegation-core';
 
 // Valid between Jan 1, 2022 and Jan 1, 2023
 const terms = createTimestampTerms({
-  timestampAfterThreshold: 1640995200,  // 2022-01-01 00:00:00 UTC
-  timestampBeforeThreshold: 1672531200  // 2023-01-01 00:00:00 UTC
+  timestampAfterThreshold: 1640995200, // 2022-01-01 00:00:00 UTC
+  timestampBeforeThreshold: 1672531200, // 2023-01-01 00:00:00 UTC
 });
 
 // Only valid after a certain time (no end time)
 const openEndedTerms = createTimestampTerms({
   timestampAfterThreshold: 1640995200,
-  timestampBeforeThreshold: 0
+  timestampBeforeThreshold: 0,
 });
 ```
 
@@ -88,24 +96,27 @@ const openEndedTerms = createTimestampTerms({
 Creates terms for an ExactCalldata caveat that ensures execution calldata matches exactly.
 
 **Parameters:**
+
 - `terms: ExactCalldataTerms`
-  - `callData: BytesLike` - The expected calldata (hex string or Uint8Array)
+  - `calldata: BytesLike` - The expected calldata (hex string or Uint8Array)
 - `options?: EncodingOptions` - Optional encoding options
 
 **Returns:** `Hex | Uint8Array` - The calldata itself (variable length)
 
 **Example:**
+
 ```typescript
 import { createExactCalldataTerms } from '@metamask/delegation-core';
 
 // Exact calldata for a specific function call
 const terms = createExactCalldataTerms({
-  callData: '0xa9059cbb000000000000000000000000742d35cc6634c0532925a3b8d40ec49b0e8baa5e0000000000000000000000000000000000000000000000000de0b6b3a7640000'
+  calldata:
+    '0xa9059cbb000000000000000000000000742d35cc6634c0532925a3b8d40ec49b0e8baa5e0000000000000000000000000000000000000000000000000de0b6b3a7640000',
 });
 
 // From Uint8Array
 const terms2 = createExactCalldataTerms({
-  callData: new Uint8Array([0xa9, 0x05, 0x9c, 0xbb, /* ... */])
+  calldata: new Uint8Array([0xa9, 0x05, 0x9c, 0xbb /* ... */]),
 });
 ```
 
@@ -114,6 +125,7 @@ const terms2 = createExactCalldataTerms({
 Creates terms for periodic native token transfer limits with time-based resets.
 
 **Parameters:**
+
 - `terms: NativeTokenPeriodTransferTerms`
   - `periodAmount: bigint` - Maximum amount transferable per period (wei)
   - `periodDuration: number` - Duration of each period (seconds)
@@ -123,14 +135,15 @@ Creates terms for periodic native token transfer limits with time-based resets.
 **Returns:** `Hex | Uint8Array` - 96-byte encoded terms (32 bytes per parameter)
 
 **Example:**
+
 ```typescript
 import { createNativeTokenPeriodTransferTerms } from '@metamask/delegation-core';
 
 // Allow 1 ETH per day starting from a specific date
 const terms = createNativeTokenPeriodTransferTerms({
-  periodAmount: 1000000000000000000n,  // 1 ETH in wei
-  periodDuration: 86400,               // 24 hours in seconds
-  startDate: 1640995200                // 2022-01-01 00:00:00 UTC
+  periodAmount: 1000000000000000000n, // 1 ETH in wei
+  periodDuration: 86400, // 24 hours in seconds
+  startDate: 1640995200, // 2022-01-01 00:00:00 UTC
 });
 ```
 
@@ -139,6 +152,7 @@ const terms = createNativeTokenPeriodTransferTerms({
 Creates terms for linear streaming allowance of native tokens.
 
 **Parameters:**
+
 - `terms: NativeTokenStreamingTerms`
   - `initialAmount: bigint` - Amount available immediately (wei)
   - `maxAmount: bigint` - Maximum total transferable amount (wei)
@@ -149,15 +163,16 @@ Creates terms for linear streaming allowance of native tokens.
 **Returns:** `Hex | Uint8Array` - 128-byte encoded terms (32 bytes per parameter)
 
 **Example:**
+
 ```typescript
 import { createNativeTokenStreamingTerms } from '@metamask/delegation-core';
 
 // Stream 0.5 ETH per second, starting with 1 ETH, max 10 ETH
 const terms = createNativeTokenStreamingTerms({
-  initialAmount: 1000000000000000000n,   // 1 ETH available immediately
-  maxAmount: 10000000000000000000n,      // 10 ETH maximum
-  amountPerSecond: 500000000000000000n,  // 0.5 ETH per second
-  startTime: 1640995200                  // Start streaming at this time
+  initialAmount: 1000000000000000000n, // 1 ETH available immediately
+  maxAmount: 10000000000000000000n, // 10 ETH maximum
+  amountPerSecond: 500000000000000000n, // 0.5 ETH per second
+  startTime: 1640995200, // Start streaming at this time
 });
 ```
 
@@ -166,6 +181,7 @@ const terms = createNativeTokenStreamingTerms({
 Creates terms for linear streaming allowance of ERC20 tokens.
 
 **Parameters:**
+
 - `terms: ERC20StreamingTerms`
   - `tokenAddress: string` - ERC20 token contract address
   - `initialAmount: bigint` - Amount available immediately
@@ -177,16 +193,17 @@ Creates terms for linear streaming allowance of ERC20 tokens.
 **Returns:** `Hex | Uint8Array` - 148-byte encoded terms (20 bytes + 32 bytes × 4 parameters)
 
 **Example:**
+
 ```typescript
 import { createERC20StreamingTerms } from '@metamask/delegation-core';
 
 // Stream USDC tokens
 const terms = createERC20StreamingTerms({
   tokenAddress: '0xA0b86a33E6441E74C65c6BF2A6d73B895B9b34A2',
-  initialAmount: 1000000n,      // 1 USDC (6 decimals)
-  maxAmount: 10000000n,         // 10 USDC maximum
-  amountPerSecond: 100000n,     // 0.1 USDC per second
-  startTime: 1640995200
+  initialAmount: 1000000n, // 1 USDC (6 decimals)
+  maxAmount: 10000000n, // 10 USDC maximum
+  amountPerSecond: 100000n, // 0.1 USDC per second
+  startTime: 1640995200,
 });
 ```
 
@@ -195,6 +212,7 @@ const terms = createERC20StreamingTerms({
 Creates terms for an ERC20TokenPeriodTransfer caveat that validates that ERC20 token transfers do not exceed a specified amount within a given time period.
 
 **Parameters:**
+
 - `terms: ERC20TokenPeriodTransferTerms`
   - `tokenAddress: BytesLike` - The address of the ERC20 token.
   - `periodAmount: bigint` - The maximum amount that can be transferred within each period.
@@ -205,15 +223,16 @@ Creates terms for an ERC20TokenPeriodTransfer caveat that validates that ERC20 t
 **Returns:** `Hex | Uint8Array` - 116-byte encoded terms (20 bytes for address + 32 bytes per parameter)
 
 **Example:**
+
 ```typescript
 import { createERC20TokenPeriodTransferTerms } from '@metamask/delegation-core';
 
 // Allow 100 tokens per day starting from a specific date
 const terms = createERC20TokenPeriodTransferTerms({
   tokenAddress: '0xA0b86a33E6441E74C65c6BF2A6d73B895B9b34A2',
-  periodAmount: 100n,  // 100 tokens
-  periodDuration: 86400,  // 24 hours in seconds
-  startDate: 1640995200  // 2022-01-01 00:00:00 UTC
+  periodAmount: 100n, // 100 tokens
+  periodDuration: 86400, // 24 hours in seconds
+  startDate: 1640995200, // 2022-01-01 00:00:00 UTC
 });
 ```
 
@@ -224,11 +243,13 @@ const terms = createERC20TokenPeriodTransferTerms({
 Encodes an array of delegations into a format suitable for on-chain submission.
 
 **Parameters:**
+
 - `delegations: Delegation[]` - Array of delegation objects
 
 **Returns:** Encoded delegation data
 
 **Example:**
+
 ```typescript
 import { encodeDelegations } from '@metamask/delegation-core';
 
@@ -239,8 +260,8 @@ const delegations = [
     authority: '0x...',
     caveats: [],
     salt: 0n,
-    signature: '0x...'
-  }
+    signature: '0x...',
+  },
 ];
 
 const encoded = encodeDelegations(delegations);
@@ -251,11 +272,13 @@ const encoded = encodeDelegations(delegations);
 Decodes encoded delegation data back into delegation objects.
 
 **Parameters:**
+
 - `data` - Encoded delegation data
 
 **Returns:** `Delegation[]` - Array of decoded delegation objects
 
 **Example:**
+
 ```typescript
 import { decodeDelegations } from '@metamask/delegation-core';
 
@@ -267,6 +290,7 @@ const delegations = decodeDelegations(encodedData);
 A constant representing the root authority in the delegation hierarchy.
 
 **Example:**
+
 ```typescript
 import { ROOT_AUTHORITY } from '@metamask/delegation-core';
 
@@ -278,11 +302,13 @@ console.log(ROOT_AUTHORITY); // Root authority identifier
 Computes a hash for a given delegation object.
 
 **Parameters:**
+
 - `delegation: DelegationStruct` - The delegation object to hash
 
 **Returns:** `Hex` - The hash of the delegation
 
 **Example:**
+
 ```typescript
 import { hashDelegation } from '@metamask/delegation-core';
 
@@ -292,7 +318,7 @@ const delegation = {
   authority: '0x...',
   caveats: [],
   salt: 0n,
-  signature: '0x...'
+  signature: '0x...',
 };
 
 const hash = hashDelegation(delegation);
@@ -333,7 +359,7 @@ export type TimestampTerms = {
 };
 
 export type ExactCalldataTerms = {
-  callData: BytesLike;
+  calldata: BytesLike;
 };
 
 export type NativeTokenPeriodTransferTerms = {
@@ -365,7 +391,7 @@ All caveat builders include validation and will throw descriptive errors:
 ```typescript
 try {
   const terms = createValueLteTerms({
-    maxValue: -1n // Invalid: negative value
+    maxValue: -1n, // Invalid: negative value
   });
 } catch (error) {
   console.error(error.message); // "Invalid maxValue: must be greater than or equal to zero"

--- a/packages/delegation-core/src/caveats/exactCalldata.ts
+++ b/packages/delegation-core/src/caveats/exactCalldata.ts
@@ -13,7 +13,7 @@ import type { Hex } from '../types';
  */
 export type ExactCalldataTerms = {
   /** The expected calldata to match against. */
-  callData: BytesLike;
+  calldata: BytesLike;
 };
 
 /**
@@ -45,12 +45,12 @@ export function createExactCalldataTerms(
   terms: ExactCalldataTerms,
   encodingOptions: EncodingOptions<ResultValue> = defaultOptions,
 ): Hex | Uint8Array {
-  const { callData } = terms;
+  const { calldata } = terms;
 
-  if (typeof callData === 'string' && !callData.startsWith('0x')) {
-    throw new Error('Invalid callData: must be a hex string starting with 0x');
+  if (typeof calldata === 'string' && !calldata.startsWith('0x')) {
+    throw new Error('Invalid calldata: must be a hex string starting with 0x');
   }
 
   // For exact calldata, the terms are simply the expected calldata
-  return prepareResult(callData, encodingOptions);
+  return prepareResult(calldata, encodingOptions);
 }

--- a/packages/delegation-core/test/caveats/exactCalldata.test.ts
+++ b/packages/delegation-core/test/caveats/exactCalldata.test.ts
@@ -6,53 +6,53 @@ import type { Hex } from '../../src/types';
 describe('createExactCalldataTerms', () => {
   // Note: ExactCalldata terms length varies based on input calldata length
   it('creates valid terms for simple calldata', () => {
-    const callData = '0x1234567890abcdef';
-    const result = createExactCalldataTerms({ callData });
+    const calldata = '0x1234567890abcdef';
+    const result = createExactCalldataTerms({ calldata });
 
-    expect(result).toStrictEqual(callData);
+    expect(result).toStrictEqual(calldata);
   });
 
   it('creates valid terms for empty calldata', () => {
-    const callData = '0x';
-    const result = createExactCalldataTerms({ callData });
+    const calldata = '0x';
+    const result = createExactCalldataTerms({ calldata });
 
     expect(result).toStrictEqual('0x');
   });
 
   it('creates valid terms for function call with parameters', () => {
     // Example: transfer(address,uint256) function call
-    const callData =
+    const calldata =
       '0xa9059cbb000000000000000000000000742d35cc6634c0532925a3b8d40ec49b0e8baa5e0000000000000000000000000000000000000000000000000de0b6b3a7640000';
-    const result = createExactCalldataTerms({ callData });
+    const result = createExactCalldataTerms({ calldata });
 
-    expect(result).toStrictEqual(callData);
+    expect(result).toStrictEqual(calldata);
   });
 
   it('creates valid terms for complex calldata', () => {
-    const callData =
+    const calldata =
       '0x23b872dd000000000000000000000000742d35cc6634c0532925a3b8d40ec49b0e8baa5e000000000000000000000000742d35cc6634c0532925a3b8d40ec49b0e8baa5f0000000000000000000000000000000000000000000000000de0b6b3a7640000';
-    const result = createExactCalldataTerms({ callData });
+    const result = createExactCalldataTerms({ calldata });
 
-    expect(result).toStrictEqual(callData);
+    expect(result).toStrictEqual(calldata);
   });
 
   it('creates valid terms for uppercase hex calldata', () => {
-    const callData = '0x1234567890ABCDEF';
-    const result = createExactCalldataTerms({ callData });
+    const calldata = '0x1234567890ABCDEF';
+    const result = createExactCalldataTerms({ calldata });
 
-    expect(result).toStrictEqual(callData);
+    expect(result).toStrictEqual(calldata);
   });
 
   it('creates valid terms for mixed case hex calldata', () => {
-    const callData = '0x1234567890AbCdEf';
-    const result = createExactCalldataTerms({ callData });
+    const calldata = '0x1234567890AbCdEf';
+    const result = createExactCalldataTerms({ calldata });
 
-    expect(result).toStrictEqual(callData);
+    expect(result).toStrictEqual(calldata);
   });
 
   it('creates valid terms for very long calldata', () => {
     const longCalldata: Hex = `0x${'a'.repeat(1000)}`;
-    const result = createExactCalldataTerms({ callData: longCalldata });
+    const result = createExactCalldataTerms({ calldata: longCalldata });
 
     expect(result).toStrictEqual(longCalldata);
   });
@@ -61,50 +61,50 @@ describe('createExactCalldataTerms', () => {
     const invalidCallData = '1234567890abcdef';
 
     expect(() =>
-      createExactCalldataTerms({ callData: invalidCallData as Hex }),
-    ).toThrow('Invalid callData: must be a hex string starting with 0x');
+      createExactCalldataTerms({ calldata: invalidCallData as Hex }),
+    ).toThrow('Invalid calldata: must be a hex string starting with 0x');
   });
 
   it('throws an error for empty string', () => {
     const invalidCallData = '';
 
     expect(() =>
-      createExactCalldataTerms({ callData: invalidCallData as Hex }),
-    ).toThrow('Invalid callData: must be a hex string starting with 0x');
+      createExactCalldataTerms({ calldata: invalidCallData as Hex }),
+    ).toThrow('Invalid calldata: must be a hex string starting with 0x');
   });
 
   it('throws an error for malformed hex prefix', () => {
     const invalidCallData = '0X1234'; // uppercase X
 
     expect(() =>
-      createExactCalldataTerms({ callData: invalidCallData as Hex }),
-    ).toThrow('Invalid callData: must be a hex string starting with 0x');
+      createExactCalldataTerms({ calldata: invalidCallData as Hex }),
+    ).toThrow('Invalid calldata: must be a hex string starting with 0x');
   });
 
   it('throws an error for undefined callData', () => {
     expect(() =>
-      createExactCalldataTerms({ callData: undefined as any }),
+      createExactCalldataTerms({ calldata: undefined as any }),
     ).toThrow();
   });
 
   it('throws an error for null callData', () => {
-    expect(() => createExactCalldataTerms({ callData: null as any })).toThrow();
+    expect(() => createExactCalldataTerms({ calldata: null as any })).toThrow();
   });
 
   it('throws an error for non-string non-Uint8Array callData', () => {
-    expect(() => createExactCalldataTerms({ callData: 1234 as any })).toThrow();
+    expect(() => createExactCalldataTerms({ calldata: 1234 as any })).toThrow();
   });
 
   it('handles single function selector', () => {
     const functionSelector = '0xa9059cbb'; // transfer(address,uint256) selector
-    const result = createExactCalldataTerms({ callData: functionSelector });
+    const result = createExactCalldataTerms({ calldata: functionSelector });
 
     expect(result).toStrictEqual(functionSelector);
   });
 
   it('handles calldata with odd length', () => {
     const oddLengthCalldata = '0x123';
-    const result = createExactCalldataTerms({ callData: oddLengthCalldata });
+    const result = createExactCalldataTerms({ calldata: oddLengthCalldata });
 
     expect(result).toStrictEqual(oddLengthCalldata);
   });
@@ -112,8 +112,8 @@ describe('createExactCalldataTerms', () => {
   // Tests for bytes return type
   describe('bytes return type', () => {
     it('returns Uint8Array when bytes encoding is specified', () => {
-      const callData = '0x1234567890abcdef';
-      const result = createExactCalldataTerms({ callData }, { out: 'bytes' });
+      const calldata = '0x1234567890abcdef';
+      const result = createExactCalldataTerms({ calldata }, { out: 'bytes' });
 
       expect(result).toBeInstanceOf(Uint8Array);
       expect(Array.from(result)).toEqual([
@@ -122,17 +122,17 @@ describe('createExactCalldataTerms', () => {
     });
 
     it('returns Uint8Array for empty calldata with bytes encoding', () => {
-      const callData = '0x';
-      const result = createExactCalldataTerms({ callData }, { out: 'bytes' });
+      const calldata = '0x';
+      const result = createExactCalldataTerms({ calldata }, { out: 'bytes' });
 
       expect(result).toBeInstanceOf(Uint8Array);
       expect(result).toHaveLength(0);
     });
 
     it('returns Uint8Array for complex calldata with bytes encoding', () => {
-      const callData =
+      const calldata =
         '0xa9059cbb000000000000000000000000742d35cc6634c0532925a3b8d40ec49b0e8baa5e0000000000000000000000000000000000000000000000000de0b6b3a7640000';
-      const result = createExactCalldataTerms({ callData }, { out: 'bytes' });
+      const result = createExactCalldataTerms({ calldata }, { out: 'bytes' });
 
       expect(result).toBeInstanceOf(Uint8Array);
       expect(result).toHaveLength(68); // 4 bytes selector + 32 bytes address + 32 bytes amount
@@ -141,18 +141,18 @@ describe('createExactCalldataTerms', () => {
 
   // Tests for Uint8Array input parameter
   describe('Uint8Array input parameter', () => {
-    it('accepts Uint8Array as callData parameter', () => {
+    it('accepts Uint8Array as calldata parameter', () => {
       const callDataBytes = new Uint8Array([
         0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef,
       ]);
-      const result = createExactCalldataTerms({ callData: callDataBytes });
+      const result = createExactCalldataTerms({ calldata: callDataBytes });
 
       expect(result).toStrictEqual('0x1234567890abcdef');
     });
 
-    it('accepts empty Uint8Array as callData parameter', () => {
+    it('accepts empty Uint8Array as calldata parameter', () => {
       const callDataBytes = new Uint8Array([]);
-      const result = createExactCalldataTerms({ callData: callDataBytes });
+      const result = createExactCalldataTerms({ calldata: callDataBytes });
 
       expect(result).toStrictEqual('0x');
     });
@@ -229,7 +229,7 @@ describe('createExactCalldataTerms', () => {
         0x00,
         0x00, // amount
       ]);
-      const result = createExactCalldataTerms({ callData: callDataBytes });
+      const result = createExactCalldataTerms({ calldata: callDataBytes });
 
       expect(result).toStrictEqual(
         '0xa9059cbb000000000000000000000000742d35cc6634c0532925a3b8d40ec49b0e8baa5e0000000000000000000000000000000000000000000000000de0b6b3a7640000',
@@ -239,7 +239,7 @@ describe('createExactCalldataTerms', () => {
     it('returns Uint8Array when input is Uint8Array and bytes encoding is specified', () => {
       const callDataBytes = new Uint8Array([0x12, 0x34, 0x56, 0x78]);
       const result = createExactCalldataTerms(
-        { callData: callDataBytes },
+        { calldata: callDataBytes },
         { out: 'bytes' },
       );
 

--- a/packages/delegation-toolkit/src/caveatBuilder/allowedCalldataBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/allowedCalldataBuilder.ts
@@ -4,20 +4,25 @@ import type { DeleGatorEnvironment, Caveat } from '../types';
 
 export const allowedCalldata = 'allowedCalldata';
 
+export type AllowedCalldataBuilderConfig = {
+  startIndex: number;
+  value: Hex;
+};
+
 /**
  * Builds a caveat struct for AllowedCalldataEnforcer that restricts calldata to a specific value at a given index.
  *
  * @param environment - The DeleGator environment.
- * @param startIndex - The start index of the subset of calldata bytes.
- * @param value - The expected value for the subset of calldata.
+ * @param config - The configuration object containing startIndex and value.
  * @returns The Caveat.
  * @throws Error if the value is not a valid hex string, if startIndex is negative, or if startIndex is not a whole number.
  */
 export const allowedCalldataBuilder = (
   environment: DeleGatorEnvironment,
-  startIndex: number,
-  value: Hex,
+  config: AllowedCalldataBuilderConfig,
 ): Caveat => {
+  const { startIndex, value } = config;
+
   if (!isHex(value)) {
     throw new Error('Invalid value: must be a valid hex string');
   }

--- a/packages/delegation-toolkit/src/caveatBuilder/allowedMethodsBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/allowedMethodsBuilder.ts
@@ -10,18 +10,24 @@ export type MethodSelector = Hex | string | AbiFunction;
 // length of function selector in chars, _including_ 0x prefix
 const FUNCTION_SELECTOR_STRING_LENGTH = 10;
 
+export type AllowedMethodsBuilderConfig = {
+  selectors: MethodSelector[];
+};
+
 /**
  * Builds a caveat struct for the AllowedMethodsEnforcer.
  *
  * @param environment - The DeleGator environment.
- * @param selectors - The allowed function selectors.
+ * @param config - The configuration object containing the allowed function selectors.
  * @returns The Caveat.
  * @throws Error if no selectors are provided or if any selector is invalid.
  */
 export const allowedMethodsBuilder = (
   environment: DeleGatorEnvironment,
-  selectors: MethodSelector[],
+  config: AllowedMethodsBuilderConfig,
 ): Caveat => {
+  const { selectors } = config;
+
   if (selectors.length === 0) {
     throw new Error('Invalid selectors: must provide at least one selector');
   }

--- a/packages/delegation-toolkit/src/caveatBuilder/allowedTargetsBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/allowedTargetsBuilder.ts
@@ -4,18 +4,24 @@ import type { Caveat, DeleGatorEnvironment } from '../types';
 
 export const allowedTargets = 'allowedTargets';
 
+export type AllowedTargetsBuilderConfig = {
+  targets: Address[];
+};
+
 /**
  * Builds a caveat struct for AllowedTargetsEnforcer.
  *
  * @param environment - The DeleGator environment.
- * @param targets - The array of allowed target addresses.
+ * @param config - The configuration object containing the targets.
  * @returns The Caveat.
  * @throws Error if no targets are provided or if any of the addresses are invalid.
  */
 export const allowedTargetsBuilder = (
   environment: DeleGatorEnvironment,
-  targets: Address[],
+  config: AllowedTargetsBuilderConfig,
 ): Caveat => {
+  const { targets } = config;
+
   if (targets.length === 0) {
     throw new Error(
       'Invalid targets: must provide at least one target address',

--- a/packages/delegation-toolkit/src/caveatBuilder/argsEqualityCheckBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/argsEqualityCheckBuilder.ts
@@ -4,23 +4,26 @@ import type { DeleGatorEnvironment, Caveat } from '../types';
 
 export const argsEqualityCheck = 'argsEqualityCheck';
 
+export type ArgsEqualityCheckBuilderConfig = {
+  expectedArgs: Hex;
+};
+
 /**
  * Builds a caveat struct for the ArgsEqualityCheckEnforcer.
  *
  * @param environment - The DeleGator environment.
- * @param args - The expected value for args.
+ * @param config - The configuration object for the builder.
  * @returns The Caveat.
- * @throws Error if the args is invalid.
+ * @throws Error if the config is invalid.
  */
 export const argsEqualityCheckBuilder = (
   environment: DeleGatorEnvironment,
-  args: Hex,
+  config: ArgsEqualityCheckBuilderConfig,
 ): Caveat => {
-  if (!isHex(args)) {
-    throw new Error('Invalid args: must be a valid hex string');
+  const { expectedArgs } = config;
+  if (!isHex(expectedArgs)) {
+    throw new Error('Invalid config: expectedArgs must be a valid hex string');
   }
-
-  const terms = args;
 
   const {
     caveatEnforcers: { ArgsEqualityCheckEnforcer },
@@ -32,7 +35,7 @@ export const argsEqualityCheckBuilder = (
 
   return {
     enforcer: ArgsEqualityCheckEnforcer,
-    terms,
+    terms: expectedArgs,
     args: '0x',
   };
 };

--- a/packages/delegation-toolkit/src/caveatBuilder/blockNumberBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/blockNumberBuilder.ts
@@ -4,20 +4,25 @@ import type { DeleGatorEnvironment, Caveat } from '../types';
 
 export const blockNumber = 'blockNumber';
 
+export type BlockNumberBuilderConfig = {
+  blockAfterThreshold: bigint;
+  blockBeforeThreshold: bigint;
+};
+
 /**
  * Builds a caveat struct for the BlockNumberEnforcer.
  *
  * @param environment - The DeleGator environment.
- * @param blockAfterThreshold - The earliest block number after which the delegation can be used.
- * @param blockBeforeThreshold - The latest block number before which the delegation can be used.
+ * @param config - The configuration object for the BlockNumberEnforcer.
  * @returns The Caveat.
  * @throws Error if both thresholds are zero, if blockAfterThreshold is greater than or equal to blockBeforeThreshold, or if BlockNumberEnforcer is not available in the environment.
  */
 export const blockNumberBuilder = (
   environment: DeleGatorEnvironment,
-  blockAfterThreshold: bigint,
-  blockBeforeThreshold: bigint,
+  config: BlockNumberBuilderConfig,
 ): Caveat => {
+  const { blockAfterThreshold, blockBeforeThreshold } = config;
+
   if (blockAfterThreshold === 0n && blockBeforeThreshold === 0n) {
     throw new Error(
       'Invalid thresholds: At least one of blockAfterThreshold or blockBeforeThreshold must be specified',

--- a/packages/delegation-toolkit/src/caveatBuilder/blockNumberBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/blockNumberBuilder.ts
@@ -61,5 +61,3 @@ export const blockNumberBuilder = (
     args: '0x',
   };
 };
-
-type A = { type: 'a' } | { type: 'b' };

--- a/packages/delegation-toolkit/src/caveatBuilder/blockNumberBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/blockNumberBuilder.ts
@@ -61,3 +61,5 @@ export const blockNumberBuilder = (
     args: '0x',
   };
 };
+
+type A = { type: 'a' } | { type: 'b' };

--- a/packages/delegation-toolkit/src/caveatBuilder/caveatBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/caveatBuilder.ts
@@ -1,7 +1,4 @@
 import type { Caveat, DeleGatorEnvironment } from '../types';
-import { createCaveatBuilderFromScope, type ScopeConfig } from './scope';
-
-export type Caveats = CaveatBuilder | Caveat[];
 
 type CaveatWithOptionalArgs = Omit<Caveat, 'args'> & {
   args?: Caveat['args'];
@@ -9,32 +6,6 @@ type CaveatWithOptionalArgs = Omit<Caveat, 'args'> & {
 
 const INSECURE_UNRESTRICTED_DELEGATION_ERROR_MESSAGE =
   'No caveats found. If you definitely want to create an empty caveat collection, set `allowInsecureUnrestrictedDelegation` to `true`.';
-
-/**
- * Resolves the array of Caveat from a Caveats argument.
- * @param config - The configuration for the caveat builder.
- * @param config.environment - The environment to be used for the caveat builder.
- * @param config.scope - The scope to be used for the caveat builder.
- * @param config.caveats - The caveats to be resolved, which can be either a CaveatBuilder or an array of Caveat.
- * @returns The resolved array of caveats.
- */
-export const resolveCaveats = ({
-  environment,
-  scope,
-  caveats,
-}: {
-  environment: DeleGatorEnvironment;
-  scope: ScopeConfig;
-  caveats: Caveats;
-}) => {
-  const scopeCaveatBuilder = createCaveatBuilderFromScope(environment, scope);
-
-  const additionalCaveats = Array.isArray(caveats) ? caveats : caveats.build();
-
-  additionalCaveats.forEach((caveat) => scopeCaveatBuilder.addCaveat(caveat));
-
-  return scopeCaveatBuilder.build();
-};
 
 type CaveatBuilderMap = {
   [key: string]: (

--- a/packages/delegation-toolkit/src/caveatBuilder/caveatBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/caveatBuilder.ts
@@ -36,13 +36,6 @@ export const resolveCaveats = ({
   return scopeCaveatBuilder.build();
 };
 
-type RemoveFirst<TypeArray extends any[]> = TypeArray extends [
-  any,
-  ...infer Rest,
-]
-  ? Rest
-  : never;
-
 type CaveatBuilderMap = {
   [key: string]: (
     environment: DeleGatorEnvironment,
@@ -95,7 +88,7 @@ export class CaveatBuilder<
     TEnforcerName extends string,
     TFunction extends (
       environment: DeleGatorEnvironment,
-      ...args: [...any]
+      config: any,
     ) => Caveat,
   >(
     name: TEnforcerName,
@@ -121,19 +114,17 @@ export class CaveatBuilder<
   /**
    * Adds a caveat using a named enforcer function.
    * @param name - The name of the enforcer function to use.
-   * @param args - The arguments to pass to the enforcer function.
+   * @param config - The configuration to pass to the enforcer function.
    * @returns The CaveatBuilder instance for chaining.
    */
   addCaveat<TEnforcerName extends keyof TCaveatBuilderMap>(
     name: TEnforcerName,
-    ...args: RemoveFirst<Parameters<TCaveatBuilderMap[TEnforcerName]>>
+    config: Parameters<TCaveatBuilderMap[TEnforcerName]>[1],
   ): CaveatBuilder<TCaveatBuilderMap>;
 
   addCaveat<TEnforcerName extends keyof TCaveatBuilderMap>(
     nameOrCaveat: TEnforcerName | CaveatWithOptionalArgs,
-    ...args: typeof nameOrCaveat extends CaveatWithOptionalArgs
-      ? []
-      : RemoveFirst<Parameters<TCaveatBuilderMap[TEnforcerName]>>
+    config?: Parameters<TCaveatBuilderMap[TEnforcerName]>[1],
   ): CaveatBuilder<TCaveatBuilderMap> {
     if (typeof nameOrCaveat === 'object') {
       const caveat = {
@@ -149,7 +140,7 @@ export class CaveatBuilder<
 
     const func = this.#enforcerBuilders[name];
     if (typeof func === 'function') {
-      const result = func(this.#environment, ...args);
+      const result = func(this.#environment, config);
 
       this.#results = [...this.#results, result];
 

--- a/packages/delegation-toolkit/src/caveatBuilder/caveatBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/caveatBuilder.ts
@@ -6,13 +6,25 @@ type CaveatWithOptionalArgs = Omit<Caveat, 'args'> & {
   args?: Caveat['args'];
 };
 
+const INSECURE_UNRESTRICTED_DELEGATION_ERROR_MESSAGE =
+  'No caveats found. If you definitely want to create an empty caveat collection, set `allowInsecureUnrestrictedDelegation` to `true`.';
+
 /**
  * Resolves the array of Caveat from a Caveats argument.
  * @param caveats - The caveats to be resolved, which can be either a CaveatBuilder or an array of Caveat.
  * @returns The resolved array of caveats.
  */
-export const resolveCaveats = (caveats: Caveats) => {
+export const resolveCaveats = ({
+  caveats,
+  allowInsecureUnrestrictedDelegation = false,
+}: {
+  caveats: Caveats;
+  allowInsecureUnrestrictedDelegation?: boolean;
+}) => {
   if (Array.isArray(caveats)) {
+    if (caveats.length === 0 && !allowInsecureUnrestrictedDelegation) {
+      throw new Error(INSECURE_UNRESTRICTED_DELEGATION_ERROR_MESSAGE);
+    }
     return caveats;
   }
   return caveats.build();
@@ -33,7 +45,7 @@ type CaveatBuilderMap = {
 };
 
 export type CaveatBuilderConfig = {
-  allowEmptyCaveats?: boolean;
+  allowInsecureUnrestrictedDelegation?: boolean;
 };
 
 /**
@@ -150,10 +162,11 @@ export class CaveatBuilder<
       throw new Error('This CaveatBuilder has already been built.');
     }
 
-    if (this.#results.length === 0 && !this.#config.allowEmptyCaveats) {
-      throw new Error(
-        'No caveats found. If you definitely want to create an empty caveat collection, set `allowEmptyCaveats`.',
-      );
+    if (
+      this.#results.length === 0 &&
+      !this.#config.allowInsecureUnrestrictedDelegation
+    ) {
+      throw new Error(INSECURE_UNRESTRICTED_DELEGATION_ERROR_MESSAGE);
     }
 
     this.#hasBeenBuilt = true;

--- a/packages/delegation-toolkit/src/caveatBuilder/caveatBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/caveatBuilder.ts
@@ -12,6 +12,8 @@ const INSECURE_UNRESTRICTED_DELEGATION_ERROR_MESSAGE =
 /**
  * Resolves the array of Caveat from a Caveats argument.
  * @param caveats - The caveats to be resolved, which can be either a CaveatBuilder or an array of Caveat.
+ * @param caveats.caveats - The caveats to be resolved, which can be either a CaveatBuilder or an array of Caveat.
+ * @param caveats.allowInsecureUnrestrictedDelegation - Whether to allow insecure unrestricted delegation.
  * @returns The resolved array of caveats.
  */
 export const resolveCaveats = ({

--- a/packages/delegation-toolkit/src/caveatBuilder/coreCaveatBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/coreCaveatBuilder.ts
@@ -1,0 +1,130 @@
+import type { DeleGatorEnvironment } from '../types';
+import {
+  allowedCalldata,
+  allowedCalldataBuilder,
+} from './allowedCalldataBuilder';
+import { allowedMethods, allowedMethodsBuilder } from './allowedMethodsBuilder';
+import { allowedTargets, allowedTargetsBuilder } from './allowedTargetsBuilder';
+import {
+  argsEqualityCheck,
+  argsEqualityCheckBuilder,
+} from './argsEqualityCheckBuilder';
+import { blockNumber, blockNumberBuilder } from './blockNumberBuilder';
+import type { CaveatBuilderConfig } from './caveatBuilder';
+import { CaveatBuilder } from './caveatBuilder';
+import { deployed, deployedBuilder } from './deployedBuilder';
+import {
+  erc1155BalanceChange,
+  erc1155BalanceChangeBuilder,
+} from './erc1155BalanceChangeBuilder';
+import {
+  erc20BalanceChange,
+  erc20BalanceChangeBuilder,
+} from './erc20BalanceChangeBuilder';
+import {
+  erc20PeriodTransfer,
+  erc20PeriodTransferBuilder,
+} from './erc20PeriodTransferBuilder';
+import { erc20Streaming, erc20StreamingBuilder } from './erc20StreamingBuilder';
+import {
+  erc20TransferAmount,
+  erc20TransferAmountBuilder,
+} from './erc20TransferAmountBuilder';
+import {
+  erc721BalanceChange,
+  erc721BalanceChangeBuilder,
+} from './erc721BalanceChangeBuilder';
+import { erc721Transfer, erc721TransferBuilder } from './erc721TransferBuilder';
+import {
+  exactCalldataBatch,
+  exactCalldataBatchBuilder,
+} from './exactCalldataBatchBuilder';
+import { exactCalldata, exactCalldataBuilder } from './exactCalldataBuilder';
+import {
+  exactExecutionBatch,
+  exactExecutionBatchBuilder,
+} from './exactExecutionBatchBuilder';
+import { exactExecution, exactExecutionBuilder } from './exactExecutionBuilder';
+import { id, idBuilder } from './idBuilder';
+import { limitedCalls, limitedCallsBuilder } from './limitedCallsBuilder';
+import {
+  multiTokenPeriod,
+  multiTokenPeriodBuilder,
+} from './multiTokenPeriodBuilder';
+import {
+  nativeBalanceChange,
+  nativeBalanceChangeBuilder,
+} from './nativeBalanceChangeBuilder';
+import {
+  nativeTokenPayment,
+  nativeTokenPaymentBuilder,
+} from './nativeTokenPaymentBuilder';
+import {
+  nativeTokenPeriodTransfer,
+  nativeTokenPeriodTransferBuilder,
+} from './nativeTokenPeriodTransferBuilder';
+import {
+  nativeTokenStreaming,
+  nativeTokenStreamingBuilder,
+} from './nativeTokenStreamingBuilder';
+import {
+  nativeTokenTransferAmount,
+  nativeTokenTransferAmountBuilder,
+} from './nativeTokenTransferAmountBuilder';
+import { nonce, nonceBuilder } from './nonceBuilder';
+import { redeemer, redeemerBuilder } from './redeemerBuilder';
+import {
+  specificActionERC20TransferBatch,
+  specificActionERC20TransferBatchBuilder,
+} from './specificActionERC20TransferBatchBuilder';
+import { timestamp, timestampBuilder } from './timestampBuilder';
+import { valueLte, valueLteBuilder } from './valueLteBuilder';
+import {
+  ownershipTransfer,
+  ownershipTransferBuilder,
+} from './ownershipTransferBuilder';
+
+export const createCaveatBuilder = (
+  environment: DeleGatorEnvironment,
+  config?: CaveatBuilderConfig,
+) => {
+  const caveatBuilder = new CaveatBuilder(environment, config)
+    .extend(allowedMethods, allowedMethodsBuilder)
+    .extend(allowedTargets, allowedTargetsBuilder)
+    .extend(deployed, deployedBuilder)
+    .extend(allowedCalldata, allowedCalldataBuilder)
+    .extend(erc20BalanceChange, erc20BalanceChangeBuilder)
+    .extend(erc721BalanceChange, erc721BalanceChangeBuilder)
+    .extend(erc1155BalanceChange, erc1155BalanceChangeBuilder)
+    .extend(valueLte, valueLteBuilder)
+    .extend(limitedCalls, limitedCallsBuilder)
+    .extend(id, idBuilder)
+    .extend(nonce, nonceBuilder)
+    .extend(timestamp, timestampBuilder)
+    .extend(blockNumber, blockNumberBuilder)
+    .extend(erc20TransferAmount, erc20TransferAmountBuilder)
+    .extend(erc20Streaming, erc20StreamingBuilder)
+    .extend(nativeTokenStreaming, nativeTokenStreamingBuilder)
+    .extend(erc721Transfer, erc721TransferBuilder)
+    .extend(nativeTokenTransferAmount, nativeTokenTransferAmountBuilder)
+    .extend(nativeBalanceChange, nativeBalanceChangeBuilder)
+    .extend(redeemer, redeemerBuilder)
+    .extend(nativeTokenPayment, nativeTokenPaymentBuilder)
+    .extend(argsEqualityCheck, argsEqualityCheckBuilder)
+    .extend(
+      specificActionERC20TransferBatch,
+      specificActionERC20TransferBatchBuilder,
+    )
+    .extend(erc20PeriodTransfer, erc20PeriodTransferBuilder)
+    .extend(nativeTokenPeriodTransfer, nativeTokenPeriodTransferBuilder)
+    .extend(exactCalldataBatch, exactCalldataBatchBuilder)
+    .extend(exactCalldata, exactCalldataBuilder)
+    .extend(exactExecution, exactExecutionBuilder)
+    .extend(exactExecutionBatch, exactExecutionBatchBuilder)
+    .extend(multiTokenPeriod, multiTokenPeriodBuilder)
+    .extend(ownershipTransfer, ownershipTransferBuilder);
+
+  return caveatBuilder;
+};
+
+export type CoreCaveatBuilder = ReturnType<typeof createCaveatBuilder>;

--- a/packages/delegation-toolkit/src/caveatBuilder/coreCaveatBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/coreCaveatBuilder.ts
@@ -3,11 +3,7 @@ import {
   allowedCalldata,
   allowedCalldataBuilder,
 } from './allowedCalldataBuilder';
-import {
-  allowedMethods,
-  allowedMethodsBuilder,
-  AllowedMethodsBuilderConfig,
-} from './allowedMethodsBuilder';
+import { allowedMethods, allowedMethodsBuilder } from './allowedMethodsBuilder';
 import { allowedTargets, allowedTargetsBuilder } from './allowedTargetsBuilder';
 import {
   argsEqualityCheck,
@@ -133,24 +129,25 @@ type CoreCaveatMap = {
  */
 export type CoreCaveatBuilder = CaveatBuilder<CoreCaveatMap>;
 
-type ExtractCaveatMapType<T> = T extends CaveatBuilder<infer U> ? U : never;
+type ExtractCaveatMapType<TCaveatBuilder extends CaveatBuilder<any>> =
+  TCaveatBuilder extends CaveatBuilder<infer TCaveatMap> ? TCaveatMap : never;
 type ExtractedCoreMap = ExtractCaveatMapType<CoreCaveatBuilder>;
 
 export type CaveatConfigurations = {
-  [K in keyof ExtractedCoreMap]: {
-    type: K;
-  } & Parameters<ExtractedCoreMap[K]>[1];
+  [TType in keyof ExtractedCoreMap]: {
+    type: TType;
+  } & Parameters<ExtractedCoreMap[TType]>[1];
 }[keyof ExtractedCoreMap];
 
 export type CaveatConfiguration<
-  T extends CaveatBuilder<any>,
-  CaveatMap = ExtractCaveatMapType<T>,
+  TCaveatBuilder extends CaveatBuilder<any>,
+  CaveatMap = ExtractCaveatMapType<TCaveatBuilder>,
 > =
   CaveatMap extends Record<string, (...args: any[]) => any>
     ? {
-        [K in keyof CaveatMap]: {
-          type: K;
-        } & Parameters<CaveatMap[K]>[1];
+        [TType in keyof CaveatMap]: {
+          type: TType;
+        } & Parameters<CaveatMap[TType]>[1];
       }[keyof CaveatMap]
     : never;
 
@@ -159,9 +156,9 @@ export type CoreCaveatConfiguration = CaveatConfiguration<CoreCaveatBuilder>;
 /**
  * Creates a caveat builder with all core caveat types pre-configured.
  *
- * @param environment - The DeleGator environment configuration
- * @param config - Optional configuration for the caveat builder
- * @returns A fully configured CoreCaveatBuilder instance with all core caveat types
+ * @param environment - The DeleGator environment configuration.
+ * @param config - Optional configuration for the caveat builder.
+ * @returns A fully configured CoreCaveatBuilder instance with all core caveat types.
  */
 export const createCaveatBuilder = (
   environment: DeleGatorEnvironment,

--- a/packages/delegation-toolkit/src/caveatBuilder/coreCaveatBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/coreCaveatBuilder.ts
@@ -72,6 +72,10 @@ import {
   nativeTokenTransferAmountBuilder,
 } from './nativeTokenTransferAmountBuilder';
 import { nonce, nonceBuilder } from './nonceBuilder';
+import {
+  ownershipTransfer,
+  ownershipTransferBuilder,
+} from './ownershipTransferBuilder';
 import { redeemer, redeemerBuilder } from './redeemerBuilder';
 import {
   specificActionERC20TransferBatch,
@@ -79,10 +83,6 @@ import {
 } from './specificActionERC20TransferBatchBuilder';
 import { timestamp, timestampBuilder } from './timestampBuilder';
 import { valueLte, valueLteBuilder } from './valueLteBuilder';
-import {
-  ownershipTransfer,
-  ownershipTransferBuilder,
-} from './ownershipTransferBuilder';
 
 export const createCaveatBuilder = (
   environment: DeleGatorEnvironment,

--- a/packages/delegation-toolkit/src/caveatBuilder/deployedBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/deployedBuilder.ts
@@ -14,9 +14,10 @@ export type DeployedBuilderConfig = {
  * Builds a caveat struct for a DeployedEnforcer.
  *
  * @param environment - The DeleGator environment.
- * @param contractAddress - The address of the contract that must be deployed.
- * @param salt - The address of the factory contract.
- * @param bytecode - The bytecode of the contract to be deployed.
+ * @param config - The configuration object containing the contract address, salt, and bytecode.
+ * @param config.contractAddress - The address of the contract that must be deployed.
+ * @param config.salt - The address of the factory contract.
+ * @param config.bytecode - The bytecode of the contract to be deployed.
  * @returns The Caveat.
  * @throws Error if the contract address, factory address, or bytecode is invalid.
  */

--- a/packages/delegation-toolkit/src/caveatBuilder/deployedBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/deployedBuilder.ts
@@ -4,6 +4,12 @@ import type { Caveat, DeleGatorEnvironment } from '../types';
 
 export const deployed = 'deployed';
 
+export type DeployedBuilderConfig = {
+  contractAddress: Address;
+  salt: Hex;
+  bytecode: Hex;
+};
+
 /**
  * Builds a caveat struct for a DeployedEnforcer.
  *
@@ -16,10 +22,10 @@ export const deployed = 'deployed';
  */
 export const deployedBuilder = (
   environment: DeleGatorEnvironment,
-  contractAddress: Address,
-  salt: Hex,
-  bytecode: Hex,
+  config: DeployedBuilderConfig,
 ): Caveat => {
+  const { contractAddress, salt, bytecode } = config;
+
   // we check that the addresses are valid, but don't need to be checksummed
   if (!isAddress(contractAddress, { strict: false })) {
     throw new Error(

--- a/packages/delegation-toolkit/src/caveatBuilder/erc1155BalanceChangeBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/erc1155BalanceChangeBuilder.ts
@@ -5,26 +5,28 @@ import { BalanceChangeType } from './types';
 
 export const erc1155BalanceChange = 'erc1155BalanceChange';
 
+export type Erc1155BalanceChangeBuilderConfig = {
+  tokenAddress: Address;
+  recipient: Address;
+  tokenId: bigint;
+  balance: bigint;
+  changeType: BalanceChangeType;
+};
+
 /**
  * Builds a caveat struct for the ERC1155BalanceChangeEnforcer.
  *
  * @param environment - The DeleGator environment.
- * @param tokenAddress - The tokenAddress of the ERC1155 token.
- * @param recipient - The address of the recipient whose balance must change.
- * @param tokenId - The ID of the ERC1155 token.
- * @param balance - The amount by which the recipient's balance must change.
- * @param changeType - The type of balance change (increase or decrease).
+ * @param config - The configuration object for the ERC1155 balance change.
  * @returns The Caveat.
  * @throws Error if the token address is invalid, the recipient address is invalid, or the amount is not a positive number.
  */
 export const erc1155BalanceChangeBuilder = (
   environment: DeleGatorEnvironment,
-  tokenAddress: Address,
-  recipient: Address,
-  tokenId: bigint,
-  balance: bigint,
-  changeType: BalanceChangeType,
+  config: Erc1155BalanceChangeBuilderConfig,
 ): Caveat => {
+  const { tokenAddress, recipient, tokenId, balance, changeType } = config;
+
   if (!isAddress(tokenAddress, { strict: false })) {
     throw new Error('Invalid tokenAddress: must be a valid address');
   }

--- a/packages/delegation-toolkit/src/caveatBuilder/erc20BalanceChangeBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/erc20BalanceChangeBuilder.ts
@@ -5,24 +5,27 @@ import { BalanceChangeType } from './types';
 
 export const erc20BalanceChange = 'erc20BalanceChange';
 
+export type Erc20BalanceChangeBuilderConfig = {
+  tokenAddress: Address;
+  recipient: Address;
+  balance: bigint;
+  changeType: BalanceChangeType;
+};
+
 /**
  * Builds a caveat struct for the ERC20BalanceChangeEnforcer.
  *
  * @param environment - The DeleGator environment.
- * @param tokenAddress - The tokenAddress of the ERC20 token.
- * @param recipient - The address of the recipient whose balance must change.
- * @param balance - The minimum balance amount required.
- * @param changeType - Whether the balance should increase or decrease.
+ * @param config - The configuration object for the ERC20 balance change.
  * @returns The Caveat.
  * @throws Error if the token address is invalid, the amount is not a positive number, or the change type is invalid.
  */
 export const erc20BalanceChangeBuilder = (
   environment: DeleGatorEnvironment,
-  tokenAddress: Address,
-  recipient: Address,
-  balance: bigint,
-  changeType: BalanceChangeType,
+  config: Erc20BalanceChangeBuilderConfig,
 ): Caveat => {
+  const { tokenAddress, recipient, balance, changeType } = config;
+
   if (!isAddress(tokenAddress, { strict: false })) {
     throw new Error('Invalid tokenAddress: must be a valid address');
   }

--- a/packages/delegation-toolkit/src/caveatBuilder/erc20PeriodTransferBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/erc20PeriodTransferBuilder.ts
@@ -19,10 +19,11 @@ export type Erc20PeriodTransferBuilderConfig = {
  * and any unused tokens are forfeited once the period ends.
  *
  * @param environment - The DeleGator environment.
- * @param tokenAddress - The address of the ERC20 token contract.
- * @param periodAmount - The maximum amount of tokens that can be transferred per period.
- * @param periodDuration - The duration of each period in seconds.
- * @param startDate - The timestamp when the first period begins.
+ * @param config - The configuration object containing the token address, period amount, period duration, and start date.
+ * @param config.tokenAddress - The address of the ERC20 token contract.
+ * @param config.periodAmount - The maximum amount of tokens that can be transferred per period.
+ * @param config.periodDuration - The duration of each period in seconds.
+ * @param config.startDate - The timestamp when the first period begins.
  * @returns The Caveat.
  * @throws Error if the token address is invalid or if any of the numeric parameters are invalid.
  */

--- a/packages/delegation-toolkit/src/caveatBuilder/erc20PeriodTransferBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/erc20PeriodTransferBuilder.ts
@@ -5,6 +5,13 @@ import type { Caveat, DeleGatorEnvironment } from '../types';
 
 export const erc20PeriodTransfer = 'erc20PeriodTransfer';
 
+export type Erc20PeriodTransferBuilderConfig = {
+  tokenAddress: Address;
+  periodAmount: bigint;
+  periodDuration: number;
+  startDate: number;
+};
+
 /**
  * Builds a caveat struct for ERC20PeriodTransferEnforcer.
  * This enforcer validates that ERC20 token transfers do not exceed a specified amount
@@ -21,11 +28,10 @@ export const erc20PeriodTransfer = 'erc20PeriodTransfer';
  */
 export const erc20PeriodTransferBuilder = (
   environment: DeleGatorEnvironment,
-  tokenAddress: Address,
-  periodAmount: bigint,
-  periodDuration: number,
-  startDate: number,
+  config: Erc20PeriodTransferBuilderConfig,
 ): Caveat => {
+  const { tokenAddress, periodAmount, periodDuration, startDate } = config;
+
   const terms = createERC20TokenPeriodTransferTerms({
     tokenAddress,
     periodAmount,

--- a/packages/delegation-toolkit/src/caveatBuilder/erc20StreamingBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/erc20StreamingBuilder.ts
@@ -5,6 +5,14 @@ import type { DeleGatorEnvironment, Caveat } from '../types';
 
 export const erc20Streaming = 'erc20Streaming';
 
+export type Erc20StreamingBuilderConfig = {
+  tokenAddress: Address;
+  initialAmount: bigint;
+  maxAmount: bigint;
+  amountPerSecond: bigint;
+  startTime: number;
+};
+
 /**
  * Builds a caveat for ERC20 token streaming with configurable parameters.
  *
@@ -24,12 +32,11 @@ export const erc20Streaming = 'erc20Streaming';
  */
 export const erc20StreamingBuilder = (
   environment: DeleGatorEnvironment,
-  tokenAddress: Address,
-  initialAmount: bigint,
-  maxAmount: bigint,
-  amountPerSecond: bigint,
-  startTime: number,
+  config: Erc20StreamingBuilderConfig,
 ): Caveat => {
+  const { tokenAddress, initialAmount, maxAmount, amountPerSecond, startTime } =
+    config;
+
   const terms = createERC20StreamingTerms({
     tokenAddress,
     initialAmount,

--- a/packages/delegation-toolkit/src/caveatBuilder/erc20StreamingBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/erc20StreamingBuilder.ts
@@ -17,11 +17,12 @@ export type Erc20StreamingBuilderConfig = {
  * Builds a caveat for ERC20 token streaming with configurable parameters.
  *
  * @param environment - The DeleGator environment.
- * @param tokenAddress - The tokenAddress of the ERC20 token.
- * @param initialAmount - The initial amount of tokens to release at start time.
- * @param maxAmount - The maximum amount of tokens that can be released.
- * @param amountPerSecond - The rate at which the allowance increases per second.
- * @param startTime - The timestamp from which the allowance streaming begins.
+ * @param config - The configuration object containing the token address, initial amount, max amount, amount per second, and start time.
+ * @param config.tokenAddress - The tokenAddress of the ERC20 token.
+ * @param config.initialAmount - The initial amount of tokens to release at start time.
+ * @param config.maxAmount - The maximum amount of tokens that can be released.
+ * @param config.amountPerSecond - The rate at which the allowance increases per second.
+ * @param config.startTime - The timestamp from which the allowance streaming begins.
  * @returns The Caveat.
  * @throws Error if the token address is invalid.
  * @throws Error if the initial amount is a negative number.

--- a/packages/delegation-toolkit/src/caveatBuilder/erc20TransferAmountBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/erc20TransferAmountBuilder.ts
@@ -5,6 +5,11 @@ import type { Caveat, DeleGatorEnvironment } from '../types';
 
 export const erc20TransferAmount = 'erc20TransferAmount';
 
+export type Erc20TransferAmountBuilderConfig = {
+  tokenAddress: Address;
+  maxAmount: bigint;
+};
+
 /**
  * Builds a caveat struct for ERC20TransferAmountEnforcer.
  *
@@ -16,9 +21,10 @@ export const erc20TransferAmount = 'erc20TransferAmount';
  */
 export const erc20TransferAmountBuilder = (
   environment: DeleGatorEnvironment,
-  tokenAddress: Address,
-  maxAmount: bigint,
+  config: Erc20TransferAmountBuilderConfig,
 ): Caveat => {
+  const { tokenAddress, maxAmount } = config;
+
   if (!isAddress(tokenAddress, { strict: false })) {
     throw new Error('Invalid tokenAddress: must be a valid address');
   }

--- a/packages/delegation-toolkit/src/caveatBuilder/erc20TransferAmountBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/erc20TransferAmountBuilder.ts
@@ -14,8 +14,9 @@ export type Erc20TransferAmountBuilderConfig = {
  * Builds a caveat struct for ERC20TransferAmountEnforcer.
  *
  * @param environment - The DeleGator environment.
- * @param tokenAddress - The address of the ERC20 token contract.
- * @param maxAmount - The maximum amount of tokens that can be transferred.
+ * @param config - The configuration object containing the token address and max amount.
+ * @param config.tokenAddress - The address of the ERC20 token contract.
+ * @param config.maxAmount - The maximum amount of tokens that can be transferred.
  * @returns The Caveat.
  * @throws Error if the token address is invalid or if the max amount is not a positive number.
  */

--- a/packages/delegation-toolkit/src/caveatBuilder/erc20UnitOfAuthority.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/erc20UnitOfAuthority.ts
@@ -1,0 +1,98 @@
+import type { UnitOfAuthorityBaseConfig } from './types';
+import { createCaveatBuilder } from './coreCaveatBuilder';
+import type { CoreCaveatBuilder } from './coreCaveatBuilder';
+import { Erc20PeriodTransferBuilderConfig } from './erc20PeriodTransferBuilder';
+import { Erc20StreamingBuilderConfig } from './erc20StreamingBuilder';
+import { Erc20TransferAmountBuilderConfig } from './erc20TransferAmountBuilder';
+import { SpecificActionErc20TransferBatchBuilderConfig } from './specificActionERC20TransferBatchBuilder';
+
+export type Erc20UnitOfAuthorityConfig = UnitOfAuthorityBaseConfig &
+  (
+    | Erc20StreamingBuilderConfig
+    | Erc20TransferAmountBuilderConfig
+    | Erc20PeriodTransferBuilderConfig
+    | SpecificActionErc20TransferBatchBuilderConfig
+  );
+
+/**
+ * Creates a caveat builder configured for ERC20 token streaming with value limits.
+ *
+ * This function creates a caveat builder that includes:
+ * - An ERC20 streaming caveat with the specified token parameters
+ * - A value limit caveat that restricts the total value to 0 (preventing native token transfers)
+ *
+ * @param config - Configuration object containing environment and ERC20 streaming parameters.
+ * @param config.environment - The DeleGator environment.
+ * @param config.tokenAddress - The address of the ERC20 token to stream.
+ * @param config.initialAmount - The initial amount of tokens available immediately.
+ * @param config.maxAmount - The maximum total amount of tokens that can be streamed.
+ * @param config.amountPerSecond - The rate at which allowance increases per second.
+ * @param config.startTime - The Unix timestamp when streaming begins.
+ * @returns A configured caveat builder with ERC20 streaming and value limit caveats.
+ * @throws Error if any of the ERC20 streaming parameters are invalid.
+ * @throws Error if the environment is not properly configured.
+ */
+export function createErc20CaveatBuilder(
+  config: Erc20UnitOfAuthorityConfig,
+): CoreCaveatBuilder {
+  const { environment } = config;
+
+  const caveatBuilder = createCaveatBuilder(environment).addCaveat('valueLte', {
+    maxValue: 0n,
+  });
+
+  if (isErc20StreamingConfig(config)) {
+    caveatBuilder.addCaveat('erc20Streaming', config);
+  } else if (isErc20PeriodTransferConfig(config)) {
+    caveatBuilder.addCaveat('erc20PeriodTransfer', config);
+  } else if (isErc20TransferAmountConfig(config)) {
+    caveatBuilder.addCaveat('erc20TransferAmount', config);
+  } else if (isSpecificActionErc20TransferBatchConfig(config)) {
+    caveatBuilder.addCaveat('specificActionERC20TransferBatch', config);
+  } else {
+    throw new Error('Invalid ERC20 configuration');
+  }
+
+  return caveatBuilder;
+}
+
+const isErc20StreamingConfig = (
+  config: Erc20UnitOfAuthorityConfig,
+): config is Erc20StreamingBuilderConfig & UnitOfAuthorityBaseConfig => {
+  return (
+    'initialAmount' in config &&
+    'maxAmount' in config &&
+    'amountPerSecond' in config &&
+    'startTime' in config
+  );
+};
+
+const isErc20TransferAmountConfig = (
+  config: Erc20UnitOfAuthorityConfig,
+): config is Erc20TransferAmountBuilderConfig & UnitOfAuthorityBaseConfig => {
+  return 'tokenAddress' in config && 'maxAmount' in config;
+};
+
+const isErc20PeriodTransferConfig = (
+  config: Erc20UnitOfAuthorityConfig,
+): config is Erc20PeriodTransferBuilderConfig & UnitOfAuthorityBaseConfig => {
+  return (
+    'tokenAddress' in config &&
+    'periodAmount' in config &&
+    'periodDuration' in config &&
+    'startDate' in config
+  );
+};
+
+const isSpecificActionErc20TransferBatchConfig = (
+  config: Erc20UnitOfAuthorityConfig,
+): config is SpecificActionErc20TransferBatchBuilderConfig &
+  UnitOfAuthorityBaseConfig => {
+  return (
+    'tokenAddress' in config &&
+    'recipient' in config &&
+    'amount' in config &&
+    'firstTarget' in config &&
+    'firstCalldata' in config
+  );
+};

--- a/packages/delegation-toolkit/src/caveatBuilder/erc20UnitOfAuthority.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/erc20UnitOfAuthority.ts
@@ -1,60 +1,10 @@
-import type { UnitOfAuthorityBaseConfig } from './types';
 import { createCaveatBuilder } from './coreCaveatBuilder';
 import type { CoreCaveatBuilder } from './coreCaveatBuilder';
-import { Erc20PeriodTransferBuilderConfig } from './erc20PeriodTransferBuilder';
-import { Erc20StreamingBuilderConfig } from './erc20StreamingBuilder';
-import { Erc20TransferAmountBuilderConfig } from './erc20TransferAmountBuilder';
-import { SpecificActionErc20TransferBatchBuilderConfig } from './specificActionERC20TransferBatchBuilder';
-
-export type Erc20UnitOfAuthorityConfig = UnitOfAuthorityBaseConfig &
-  (
-    | Erc20StreamingBuilderConfig
-    | Erc20TransferAmountBuilderConfig
-    | Erc20PeriodTransferBuilderConfig
-    | SpecificActionErc20TransferBatchBuilderConfig
-  );
-
-/**
- * Creates a caveat builder configured for ERC20 token streaming with value limits.
- *
- * This function creates a caveat builder that includes:
- * - An ERC20 streaming caveat with the specified token parameters
- * - A value limit caveat that restricts the total value to 0 (preventing native token transfers)
- *
- * @param config - Configuration object containing environment and ERC20 streaming parameters.
- * @param config.environment - The DeleGator environment.
- * @param config.tokenAddress - The address of the ERC20 token to stream.
- * @param config.initialAmount - The initial amount of tokens available immediately.
- * @param config.maxAmount - The maximum total amount of tokens that can be streamed.
- * @param config.amountPerSecond - The rate at which allowance increases per second.
- * @param config.startTime - The Unix timestamp when streaming begins.
- * @returns A configured caveat builder with ERC20 streaming and value limit caveats.
- * @throws Error if any of the ERC20 streaming parameters are invalid.
- * @throws Error if the environment is not properly configured.
- */
-export function createErc20CaveatBuilder(
-  config: Erc20UnitOfAuthorityConfig,
-): CoreCaveatBuilder {
-  const { environment } = config;
-
-  const caveatBuilder = createCaveatBuilder(environment).addCaveat('valueLte', {
-    maxValue: 0n,
-  });
-
-  if (isErc20StreamingConfig(config)) {
-    caveatBuilder.addCaveat('erc20Streaming', config);
-  } else if (isErc20PeriodTransferConfig(config)) {
-    caveatBuilder.addCaveat('erc20PeriodTransfer', config);
-  } else if (isErc20TransferAmountConfig(config)) {
-    caveatBuilder.addCaveat('erc20TransferAmount', config);
-  } else if (isSpecificActionErc20TransferBatchConfig(config)) {
-    caveatBuilder.addCaveat('specificActionERC20TransferBatch', config);
-  } else {
-    throw new Error('Invalid ERC20 configuration');
-  }
-
-  return caveatBuilder;
-}
+import type { Erc20PeriodTransferBuilderConfig } from './erc20PeriodTransferBuilder';
+import type { Erc20StreamingBuilderConfig } from './erc20StreamingBuilder';
+import type { Erc20TransferAmountBuilderConfig } from './erc20TransferAmountBuilder';
+import type { SpecificActionErc20TransferBatchBuilderConfig } from './specificActionERC20TransferBatchBuilder';
+import type { UnitOfAuthorityBaseConfig } from './types';
 
 const isErc20StreamingConfig = (
   config: Erc20UnitOfAuthorityConfig,
@@ -96,3 +46,49 @@ const isSpecificActionErc20TransferBatchConfig = (
     'firstCalldata' in config
   );
 };
+
+export type Erc20UnitOfAuthorityConfig = UnitOfAuthorityBaseConfig &
+  (
+    | Erc20StreamingBuilderConfig
+    | Erc20TransferAmountBuilderConfig
+    | Erc20PeriodTransferBuilderConfig
+    | SpecificActionErc20TransferBatchBuilderConfig
+  );
+
+/**
+ * Creates a caveat builder configured for ERC20 token streaming with value limits.
+ *
+ * @param config - Configuration object containing environment and ERC20 streaming parameters.
+ * @param config.environment - The DeleGator environment.
+ * @param config.tokenAddress - The address of the ERC20 token to stream.
+ * @param config.initialAmount - The initial amount of tokens available immediately.
+ * @param config.maxAmount - The maximum total amount of tokens that can be streamed.
+ * @param config.amountPerSecond - The rate at which allowance increases per second.
+ * @param config.startTime - The Unix timestamp when streaming begins.
+ * @returns A configured caveat builder with ERC20 streaming and value limit caveats.
+ * @throws Error if any of the ERC20 streaming parameters are invalid.
+ * @throws Error if the environment is not properly configured.
+ */
+export function createErc20CaveatBuilder(
+  config: Erc20UnitOfAuthorityConfig,
+): CoreCaveatBuilder {
+  const { environment } = config;
+
+  const caveatBuilder = createCaveatBuilder(environment).addCaveat('valueLte', {
+    maxValue: 0n,
+  });
+
+  if (isErc20StreamingConfig(config)) {
+    caveatBuilder.addCaveat('erc20Streaming', config);
+  } else if (isErc20PeriodTransferConfig(config)) {
+    caveatBuilder.addCaveat('erc20PeriodTransfer', config);
+  } else if (isErc20TransferAmountConfig(config)) {
+    caveatBuilder.addCaveat('erc20TransferAmount', config);
+  } else if (isSpecificActionErc20TransferBatchConfig(config)) {
+    caveatBuilder.addCaveat('specificActionERC20TransferBatch', config);
+  } else {
+    throw new Error('Invalid ERC20 configuration');
+  }
+
+  return caveatBuilder;
+}

--- a/packages/delegation-toolkit/src/caveatBuilder/erc721BalanceChangeBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/erc721BalanceChangeBuilder.ts
@@ -5,24 +5,27 @@ import { BalanceChangeType } from './types';
 
 export const erc721BalanceChange = 'erc721BalanceChange';
 
+export type Erc721BalanceChangeBuilderConfig = {
+  tokenAddress: Address;
+  recipient: Address;
+  amount: bigint;
+  changeType: BalanceChangeType;
+};
+
 /**
  * Builds a caveat struct for the ERC721BalanceChangeEnforcer.
  *
  * @param environment - The DeleGator environment.
- * @param tokenAddress - The tokenAddress of the ERC721 token.
- * @param recipient - The address of the recipient whose balance must change.
- * @param amount - The amount by which the recipient's balance must change.
- * @param changeType - The type of balance change (increase or decrease).
+ * @param config - The configuration object for the ERC721 balance change.
  * @returns The Caveat.
  * @throws Error if the token address is invalid, the recipient address is invalid, or the amount is not a positive number.
  */
 export const erc721BalanceChangeBuilder = (
   environment: DeleGatorEnvironment,
-  tokenAddress: Address,
-  recipient: Address,
-  amount: bigint,
-  changeType: BalanceChangeType,
+  config: Erc721BalanceChangeBuilderConfig,
 ): Caveat => {
+  const { tokenAddress, recipient, amount, changeType } = config;
+
   if (!isAddress(tokenAddress, { strict: false })) {
     throw new Error('Invalid tokenAddress: must be a valid address');
   }

--- a/packages/delegation-toolkit/src/caveatBuilder/erc721TransferBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/erc721TransferBuilder.ts
@@ -4,20 +4,25 @@ import type { DeleGatorEnvironment, Caveat } from '../types';
 
 export const erc721Transfer = 'erc721Transfer';
 
+export type Erc721TransferBuilderConfig = {
+  permittedContract: Address;
+  permittedTokenId: bigint;
+};
+
 /**
  * Builds a caveat struct for the ERC721TransferEnforcer.
  *
  * @param environment - The DeleGator environment.
- * @param permittedContract - The permitted contract address for the ERC721 token.
- * @param permittedTokenId - The permitted token ID as a bigint.
+ * @param config - The configuration object for the ERC721 transfer builder.
  * @returns The Caveat representing the caveat for ERC721 transfer.
  * @throws Error if the permitted contract address is invalid.
  */
 export const erc721TransferBuilder = (
   environment: DeleGatorEnvironment,
-  permittedContract: Address,
-  permittedTokenId: bigint,
+  config: Erc721TransferBuilderConfig,
 ): Caveat => {
+  const { permittedContract, permittedTokenId } = config;
+
   if (!isAddress(permittedContract, { strict: false })) {
     throw new Error('Invalid tokenAddress: must be a valid address');
   }

--- a/packages/delegation-toolkit/src/caveatBuilder/erc721UnitOfAuthority.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/erc721UnitOfAuthority.ts
@@ -6,11 +6,14 @@ import type { UnitOfAuthorityBaseConfig } from './types';
 export type Erc721UnitOfAuthorityConfig = UnitOfAuthorityBaseConfig &
   Erc721TransferBuilderConfig;
 
+const isErc721TransferConfig = (
+  config: Erc721UnitOfAuthorityConfig,
+): config is Erc721UnitOfAuthorityConfig => {
+  return 'permittedContract' in config && 'permittedTokenId' in config;
+};
+
 /**
  * Creates a caveat builder configured for ERC721 unit of authority.
- *
- * This function creates a caveat builder that includes:
- * - ERC721 transfer caveat
  *
  * @param config - Configuration object containing permitted contract and token ID.
  * @param config.environment - The DeleGator environment.
@@ -31,9 +34,3 @@ export function createErc721CaveatBuilder(
 
   return caveatBuilder;
 }
-
-const isErc721TransferConfig = (
-  config: Erc721UnitOfAuthorityConfig,
-): config is Erc721UnitOfAuthorityConfig => {
-  return 'permittedContract' in config && 'permittedTokenId' in config;
-};

--- a/packages/delegation-toolkit/src/caveatBuilder/erc721UnitOfAuthority.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/erc721UnitOfAuthority.ts
@@ -1,0 +1,39 @@
+import { createCaveatBuilder } from './coreCaveatBuilder';
+import type { CoreCaveatBuilder } from './coreCaveatBuilder';
+import type { Erc721TransferBuilderConfig } from './erc721TransferBuilder';
+import type { UnitOfAuthorityBaseConfig } from './types';
+
+export type Erc721UnitOfAuthorityConfig = UnitOfAuthorityBaseConfig &
+  Erc721TransferBuilderConfig;
+
+/**
+ * Creates a caveat builder configured for ERC721 unit of authority.
+ *
+ * This function creates a caveat builder that includes:
+ * - ERC721 transfer caveat
+ *
+ * @param config - Configuration object containing permitted contract and token ID.
+ * @param config.environment - The DeleGator environment.
+ * @returns A configured caveat builder with the specified caveats.
+ * @throws Error if any of the required parameters are invalid.
+ */
+export function createErc721CaveatBuilder(
+  config: Erc721UnitOfAuthorityConfig,
+): CoreCaveatBuilder {
+  if (!isErc721TransferConfig(config)) {
+    throw new Error('Invalid ERC721 configuration');
+  }
+
+  const caveatBuilder = createCaveatBuilder(config.environment).addCaveat(
+    'erc721Transfer',
+    config,
+  );
+
+  return caveatBuilder;
+}
+
+const isErc721TransferConfig = (
+  config: Erc721UnitOfAuthorityConfig,
+): config is Erc721UnitOfAuthorityConfig => {
+  return 'permittedContract' in config && 'permittedTokenId' in config;
+};

--- a/packages/delegation-toolkit/src/caveatBuilder/exactCalldataBatchBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/exactCalldataBatchBuilder.ts
@@ -5,20 +5,26 @@ import type { Caveat, DeleGatorEnvironment } from '../types';
 
 export const exactCalldataBatch = 'exactCalldataBatch';
 
+export type ExactCalldataBatchBuilderConfig = {
+  executions: ExecutionStruct[];
+};
+
 /**
  * Builds a caveat struct for ExactCalldataBatchEnforcer.
  * This enforcer ensures that the provided batch execution calldata matches exactly
  * the expected calldata for each execution.
  *
  * @param environment - The DeleGator environment.
- * @param executions - Array of expected executions, each containing target address, value, and calldata.
+ * @param config - Configuration object containing executions.
  * @returns The Caveat.
  * @throws Error if any of the executions have invalid parameters.
  */
 export const exactCalldataBatchBuilder = (
   environment: DeleGatorEnvironment,
-  executions: ExecutionStruct[],
+  config: ExactCalldataBatchBuilderConfig,
 ): Caveat => {
+  const { executions } = config;
+
   if (executions.length === 0) {
     throw new Error('Invalid executions: array cannot be empty');
   }
@@ -35,7 +41,7 @@ export const exactCalldataBatchBuilder = (
 
     if (!execution.callData.startsWith('0x')) {
       throw new Error(
-        'Invalid callData: must be a hex string starting with 0x',
+        'Invalid calldata: must be a hex string starting with 0x',
       );
     }
   }

--- a/packages/delegation-toolkit/src/caveatBuilder/exactCalldataBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/exactCalldataBuilder.ts
@@ -4,21 +4,27 @@ import type { Caveat, DeleGatorEnvironment } from '../types';
 
 export const exactCalldata = 'exactCalldata';
 
+export type ExactCalldataBuilderConfig = {
+  calldata: `0x${string}`;
+};
+
 /**
  * Builds a caveat struct for ExactCalldataEnforcer.
  * This enforcer ensures that the provided execution calldata matches exactly
  * the expected calldata.
  *
  * @param environment - The DeleGator environment.
- * @param callData - The expected calldata to match against.
+ * @param config - The configuration for the ExactCalldataBuilder.
  * @returns The Caveat.
  * @throws Error if any of the parameters are invalid.
  */
 export const exactCalldataBuilder = (
   environment: DeleGatorEnvironment,
-  callData: `0x${string}`,
+  config: ExactCalldataBuilderConfig,
 ): Caveat => {
-  const terms = createExactCalldataTerms({ callData });
+  const { calldata } = config;
+
+  const terms = createExactCalldataTerms({ calldata });
 
   const {
     caveatEnforcers: { ExactCalldataEnforcer },

--- a/packages/delegation-toolkit/src/caveatBuilder/exactExecutionBatchBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/exactExecutionBatchBuilder.ts
@@ -1,9 +1,13 @@
-import { encodeAbiParameters, isAddress } from 'viem';
+import { encodeAbiParameters, isAddress, encodePacked } from 'viem';
 
 import type { ExecutionStruct } from '../executions';
 import type { Caveat, DeleGatorEnvironment } from '../types';
 
 export const exactExecutionBatch = 'exactExecutionBatch';
+
+export type ExactExecutionBatchBuilderConfig = {
+  executions: ExecutionStruct[];
+};
 
 /**
  * Builds a caveat struct for ExactExecutionBatchEnforcer.
@@ -11,14 +15,16 @@ export const exactExecutionBatch = 'exactExecutionBatch';
  * with the expected execution (target, value, and calldata).
  *
  * @param environment - The DeleGator environment.
- * @param executions - Array of expected executions to match against.
+ * @param config - Configuration object containing executions.
  * @returns The Caveat.
  * @throws Error if any of the execution parameters are invalid.
  */
 export const exactExecutionBatchBuilder = (
   environment: DeleGatorEnvironment,
-  executions: ExecutionStruct[],
+  config: ExactExecutionBatchBuilderConfig,
 ): Caveat => {
+  const { executions } = config;
+
   if (executions.length === 0) {
     throw new Error('Invalid executions: array cannot be empty');
   }
@@ -35,7 +41,7 @@ export const exactExecutionBatchBuilder = (
 
     if (!execution.callData.startsWith('0x')) {
       throw new Error(
-        'Invalid callData: must be a hex string starting with 0x',
+        'Invalid calldata: must be a hex string starting with 0x',
       );
     }
   }

--- a/packages/delegation-toolkit/src/caveatBuilder/exactExecutionBatchBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/exactExecutionBatchBuilder.ts
@@ -1,4 +1,4 @@
-import { encodeAbiParameters, isAddress, encodePacked } from 'viem';
+import { encodeAbiParameters, isAddress } from 'viem';
 
 import type { ExecutionStruct } from '../executions';
 import type { Caveat, DeleGatorEnvironment } from '../types';

--- a/packages/delegation-toolkit/src/caveatBuilder/exactExecutionBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/exactExecutionBuilder.ts
@@ -5,20 +5,26 @@ import type { Caveat, DeleGatorEnvironment } from '../types';
 
 export const exactExecution = 'exactExecution';
 
+export type ExactExecutionBuilderConfig = {
+  execution: ExecutionStruct;
+};
+
 /**
  * Builds a caveat struct for ExactExecutionEnforcer.
  * This enforcer ensures that the provided execution matches exactly
  * with the expected execution (target, value, and calldata).
  *
  * @param environment - The DeleGator environment.
- * @param execution - The expected execution to match against.
+ * @param config - The configuration object containing the execution.
  * @returns The Caveat.
  * @throws Error if any of the execution parameters are invalid.
  */
 export const exactExecutionBuilder = (
   environment: DeleGatorEnvironment,
-  execution: ExecutionStruct,
+  config: ExactExecutionBuilderConfig,
 ): Caveat => {
+  const { execution } = config;
+
   if (!isAddress(execution.target, { strict: false })) {
     throw new Error('Invalid target: must be a valid address');
   }
@@ -28,7 +34,7 @@ export const exactExecutionBuilder = (
   }
 
   if (!execution.callData.startsWith('0x')) {
-    throw new Error('Invalid callData: must be a hex string starting with 0x');
+    throw new Error('Invalid calldata: must be a hex string starting with 0x');
   }
 
   const terms = concat([

--- a/packages/delegation-toolkit/src/caveatBuilder/functionCallUnitOfAuthority.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/functionCallUnitOfAuthority.ts
@@ -1,0 +1,59 @@
+import { createCaveatBuilder } from './coreCaveatBuilder';
+import type { CoreCaveatBuilder } from './coreCaveatBuilder';
+import type { AllowedTargetsBuilderConfig } from './allowedTargetsBuilder';
+import type { AllowedMethodsBuilderConfig } from './allowedMethodsBuilder';
+import type { AllowedCalldataBuilderConfig } from './allowedCalldataBuilder';
+import type { ExactCalldataBuilderConfig } from './exactCalldataBuilder';
+import { UnitOfAuthorityBaseConfig } from './types';
+
+export type FunctionCallUnitOfAuthorityConfig = UnitOfAuthorityBaseConfig &
+  AllowedTargetsBuilderConfig &
+  AllowedMethodsBuilderConfig & {
+    allowedCalldata?: AllowedCalldataBuilderConfig[];
+    exactCalldata?: ExactCalldataBuilderConfig;
+  };
+
+/**
+ * Creates a caveat builder configured for function call unit of authority.
+ *
+ * This function creates a caveat builder that includes:
+ * - Allowed targets caveat
+ * - Allowed methods caveat
+ * - Optionally, allowed calldata caveat
+ *
+ * @param config - Configuration object containing allowed targets, methods, and optionally calldata.
+ * @param config.environment - The DeleGator environment.
+ * @returns A configured caveat builder with the specified caveats.
+ * @throws Error if any of the required parameters are invalid.
+ */
+export function createFunctionCallCaveatBuilder(
+  config: FunctionCallUnitOfAuthorityConfig,
+): CoreCaveatBuilder {
+  const { environment, targets, selectors, allowedCalldata, exactCalldata } =
+    config;
+
+  if (!isFunctionCallConfig(config)) {
+    throw new Error('Invalid Function Call configuration');
+  }
+
+  const caveatBuilder = createCaveatBuilder(environment)
+    .addCaveat('allowedTargets', { targets })
+    .addCaveat('allowedMethods', { selectors });
+
+  if (allowedCalldata) {
+    allowedCalldata.forEach((calldataConfig) => {
+      caveatBuilder.addCaveat('allowedCalldata', calldataConfig);
+    });
+  }
+  if (exactCalldata) {
+    caveatBuilder.addCaveat('exactCalldata', exactCalldata);
+  }
+
+  return caveatBuilder;
+}
+
+const isFunctionCallConfig = (
+  config: FunctionCallUnitOfAuthorityConfig,
+): config is FunctionCallUnitOfAuthorityConfig => {
+  return 'targets' in config && 'selectors' in config;
+};

--- a/packages/delegation-toolkit/src/caveatBuilder/functionCallUnitOfAuthority.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/functionCallUnitOfAuthority.ts
@@ -1,10 +1,10 @@
+import type { AllowedCalldataBuilderConfig } from './allowedCalldataBuilder';
+import type { AllowedMethodsBuilderConfig } from './allowedMethodsBuilder';
+import type { AllowedTargetsBuilderConfig } from './allowedTargetsBuilder';
 import { createCaveatBuilder } from './coreCaveatBuilder';
 import type { CoreCaveatBuilder } from './coreCaveatBuilder';
-import type { AllowedTargetsBuilderConfig } from './allowedTargetsBuilder';
-import type { AllowedMethodsBuilderConfig } from './allowedMethodsBuilder';
-import type { AllowedCalldataBuilderConfig } from './allowedCalldataBuilder';
 import type { ExactCalldataBuilderConfig } from './exactCalldataBuilder';
-import { UnitOfAuthorityBaseConfig } from './types';
+import type { UnitOfAuthorityBaseConfig } from './types';
 
 export type FunctionCallUnitOfAuthorityConfig = UnitOfAuthorityBaseConfig &
   AllowedTargetsBuilderConfig &
@@ -13,13 +13,14 @@ export type FunctionCallUnitOfAuthorityConfig = UnitOfAuthorityBaseConfig &
     exactCalldata?: ExactCalldataBuilderConfig;
   };
 
+const isFunctionCallConfig = (
+  config: FunctionCallUnitOfAuthorityConfig,
+): config is FunctionCallUnitOfAuthorityConfig => {
+  return 'targets' in config && 'selectors' in config;
+};
+
 /**
  * Creates a caveat builder configured for function call unit of authority.
- *
- * This function creates a caveat builder that includes:
- * - Allowed targets caveat
- * - Allowed methods caveat
- * - Optionally, allowed calldata caveat
  *
  * @param config - Configuration object containing allowed targets, methods, and optionally calldata.
  * @param config.environment - The DeleGator environment.
@@ -51,9 +52,3 @@ export function createFunctionCallCaveatBuilder(
 
   return caveatBuilder;
 }
-
-const isFunctionCallConfig = (
-  config: FunctionCallUnitOfAuthorityConfig,
-): config is FunctionCallUnitOfAuthorityConfig => {
-  return 'targets' in config && 'selectors' in config;
-};

--- a/packages/delegation-toolkit/src/caveatBuilder/idBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/idBuilder.ts
@@ -2,20 +2,26 @@ import { maxUint256, toHex } from 'viem';
 
 import type { DeleGatorEnvironment, Caveat } from '../types';
 
+export type IdBuilderConfig = {
+  idValue: bigint | number;
+};
+
 export const id = 'id';
 
 /**
  * Builds a caveat struct for the IdEnforcer.
  *
  * @param environment - The DeleGator environment.
- * @param idValue - The id to use in the caveat.
+ * @param config - The configuration object containing the id to use in the caveat.
  * @returns The Caveat.
  * @throws Error if the provided id is not a number, not an integer, or is not 32 bytes or fewer in length.
  */
-export function idBuilder(
+export const idBuilder = (
   environment: DeleGatorEnvironment,
-  idValue: bigint | number,
-): Caveat {
+  config: IdBuilderConfig,
+): Caveat => {
+  const { idValue } = config;
+
   let idValueBigInt: bigint;
 
   if (typeof idValue === 'number') {
@@ -31,7 +37,7 @@ export function idBuilder(
   }
 
   if (idValueBigInt < 0n) {
-    throw new Error('Invalid id: must be positive');
+    throw new Error('Invalid id: must be a non-negative number');
   }
 
   if (idValueBigInt > maxUint256) {
@@ -53,4 +59,4 @@ export function idBuilder(
     terms,
     args: '0x',
   };
-}
+};

--- a/packages/delegation-toolkit/src/caveatBuilder/index.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/index.ts
@@ -11,28 +11,3 @@ export { erc1155BalanceChange } from './erc1155BalanceChangeBuilder';
 export type { CoreCaveatBuilder } from './coreCaveatBuilder';
 
 export { createCaveatBuilder } from './coreCaveatBuilder';
-
-export {
-  createErc20CaveatBuilder,
-  type Erc20UnitOfAuthorityConfig,
-} from './erc20UnitOfAuthority';
-
-export {
-  createErc721CaveatBuilder,
-  type Erc721UnitOfAuthorityConfig,
-} from './erc721UnitOfAuthority';
-
-export {
-  createNativeTokenCaveatBuilder,
-  type NativeTokenUnitOfAuthorityConfig,
-} from './nativeTokenUnitOfAuthority';
-
-export {
-  createOwnershipTransferCaveatBuilder,
-  type OwnershipUnitOfAuthorityConfig,
-} from './ownershipUnitOfAuthority';
-
-export {
-  createFunctionCallCaveatBuilder,
-  type FunctionCallUnitOfAuthorityConfig,
-} from './functionCallUnitOfAuthority';

--- a/packages/delegation-toolkit/src/caveatBuilder/index.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/index.ts
@@ -1,6 +1,6 @@
-export { resolveCaveats, CaveatBuilder } from './caveatBuilder';
+export { CaveatBuilder } from './caveatBuilder';
 
-export type { Caveats, CaveatBuilderConfig } from './caveatBuilder';
+export type { CaveatBuilderConfig } from './caveatBuilder';
 
 export { nativeBalanceChange } from './nativeBalanceChangeBuilder';
 
@@ -11,3 +11,7 @@ export { erc1155BalanceChange } from './erc1155BalanceChangeBuilder';
 export type { CoreCaveatBuilder } from './coreCaveatBuilder';
 
 export { createCaveatBuilder } from './coreCaveatBuilder';
+
+export { resolveCaveats } from './resolveCaveats';
+
+export type { Caveats } from './resolveCaveats';

--- a/packages/delegation-toolkit/src/caveatBuilder/index.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/index.ts
@@ -1,131 +1,38 @@
-import type { DeleGatorEnvironment } from '../types';
-import {
-  allowedCalldata,
-  allowedCalldataBuilder,
-} from './allowedCalldataBuilder';
-import { allowedMethods, allowedMethodsBuilder } from './allowedMethodsBuilder';
-import { allowedTargets, allowedTargetsBuilder } from './allowedTargetsBuilder';
-import {
-  argsEqualityCheck,
-  argsEqualityCheckBuilder,
-} from './argsEqualityCheckBuilder';
-import { blockNumber, blockNumberBuilder } from './blockNumberBuilder';
-import type { CaveatBuilderConfig } from './caveatBuilder';
-import { CaveatBuilder } from './caveatBuilder';
-import { deployed, deployedBuilder } from './deployedBuilder';
-import {
-  erc1155BalanceChange,
-  erc1155BalanceChangeBuilder,
-} from './erc1155BalanceChangeBuilder';
-import {
-  erc20BalanceChange,
-  erc20BalanceChangeBuilder,
-} from './erc20BalanceChangeBuilder';
-import {
-  erc20PeriodTransfer,
-  erc20PeriodTransferBuilder,
-} from './erc20PeriodTransferBuilder';
-import { erc20Streaming, erc20StreamingBuilder } from './erc20StreamingBuilder';
-import {
-  erc20TransferAmount,
-  erc20TransferAmountBuilder,
-} from './erc20TransferAmountBuilder';
-import {
-  erc721BalanceChange,
-  erc721BalanceChangeBuilder,
-} from './erc721BalanceChangeBuilder';
-import { erc721Transfer, erc721TransferBuilder } from './erc721TransferBuilder';
-import {
-  exactCalldataBatch,
-  exactCalldataBatchBuilder,
-} from './exactCalldataBatchBuilder';
-import { exactCalldata, exactCalldataBuilder } from './exactCalldataBuilder';
-import {
-  exactExecutionBatch,
-  exactExecutionBatchBuilder,
-} from './exactExecutionBatchBuilder';
-import { exactExecution, exactExecutionBuilder } from './exactExecutionBuilder';
-import { id, idBuilder } from './idBuilder';
-import { limitedCalls, limitedCallsBuilder } from './limitedCallsBuilder';
-import {
-  multiTokenPeriod,
-  multiTokenPeriodBuilder,
-} from './multiTokenPeriodBuilder';
-import {
-  nativeBalanceChange,
-  nativeBalanceChangeBuilder,
-} from './nativeBalanceChangeBuilder';
-import {
-  nativeTokenPayment,
-  nativeTokenPaymentBuilder,
-} from './nativeTokenPaymentBuilder';
-import {
-  nativeTokenPeriodTransfer,
-  nativeTokenPeriodTransferBuilder,
-} from './nativeTokenPeriodTransferBuilder';
-import {
-  nativeTokenStreaming,
-  nativeTokenStreamingBuilder,
-} from './nativeTokenStreamingBuilder';
-import {
-  nativeTokenTransferAmount,
-  nativeTokenTransferAmountBuilder,
-} from './nativeTokenTransferAmountBuilder';
-import { nonce, nonceBuilder } from './nonceBuilder';
-import { redeemer, redeemerBuilder } from './redeemerBuilder';
-import {
-  specificActionERC20TransferBatch,
-  specificActionERC20TransferBatchBuilder,
-} from './specificActionERC20TransferBatchBuilder';
-import { timestamp, timestampBuilder } from './timestampBuilder';
-import { valueLte, valueLteBuilder } from './valueLteBuilder';
-
 export { resolveCaveats, CaveatBuilder } from './caveatBuilder';
+
 export type { Caveats, CaveatBuilderConfig } from './caveatBuilder';
+
 export { nativeBalanceChange } from './nativeBalanceChangeBuilder';
+
 export { erc721BalanceChange } from './erc721BalanceChangeBuilder';
+
 export { erc1155BalanceChange } from './erc1155BalanceChangeBuilder';
 
-export const createCaveatBuilder = (
-  environment: DeleGatorEnvironment,
-  config?: CaveatBuilderConfig,
-) => {
-  const caveatBuilder = new CaveatBuilder(environment, config)
-    .extend(allowedMethods, allowedMethodsBuilder)
-    .extend(allowedTargets, allowedTargetsBuilder)
-    .extend(deployed, deployedBuilder)
-    .extend(allowedCalldata, allowedCalldataBuilder)
-    .extend(erc20BalanceChange, erc20BalanceChangeBuilder)
-    .extend(erc721BalanceChange, erc721BalanceChangeBuilder)
-    .extend(erc1155BalanceChange, erc1155BalanceChangeBuilder)
-    .extend(valueLte, valueLteBuilder)
-    .extend(limitedCalls, limitedCallsBuilder)
-    .extend(id, idBuilder)
-    .extend(nonce, nonceBuilder)
-    .extend(timestamp, timestampBuilder)
-    .extend(blockNumber, blockNumberBuilder)
-    .extend(erc20TransferAmount, erc20TransferAmountBuilder)
-    .extend(erc20Streaming, erc20StreamingBuilder)
-    .extend(nativeTokenStreaming, nativeTokenStreamingBuilder)
-    .extend(erc721Transfer, erc721TransferBuilder)
-    .extend(nativeTokenTransferAmount, nativeTokenTransferAmountBuilder)
-    .extend(nativeBalanceChange, nativeBalanceChangeBuilder)
-    .extend(redeemer, redeemerBuilder)
-    .extend(nativeTokenPayment, nativeTokenPaymentBuilder)
-    .extend(argsEqualityCheck, argsEqualityCheckBuilder)
-    .extend(
-      specificActionERC20TransferBatch,
-      specificActionERC20TransferBatchBuilder,
-    )
-    .extend(erc20PeriodTransfer, erc20PeriodTransferBuilder)
-    .extend(nativeTokenPeriodTransfer, nativeTokenPeriodTransferBuilder)
-    .extend(exactCalldataBatch, exactCalldataBatchBuilder)
-    .extend(exactCalldata, exactCalldataBuilder)
-    .extend(exactExecution, exactExecutionBuilder)
-    .extend(exactExecutionBatch, exactExecutionBatchBuilder)
-    .extend(multiTokenPeriod, multiTokenPeriodBuilder);
+export type { CoreCaveatBuilder } from './coreCaveatBuilder';
 
-  return caveatBuilder;
-};
+export { createCaveatBuilder } from './coreCaveatBuilder';
 
-export type CoreCaveatBuilder = ReturnType<typeof createCaveatBuilder>;
+export {
+  createErc20CaveatBuilder,
+  type Erc20UnitOfAuthorityConfig,
+} from './erc20UnitOfAuthority';
+
+export {
+  createErc721CaveatBuilder,
+  type Erc721UnitOfAuthorityConfig,
+} from './erc721UnitOfAuthority';
+
+export {
+  createNativeTokenCaveatBuilder,
+  type NativeTokenUnitOfAuthorityConfig,
+} from './nativeTokenUnitOfAuthority';
+
+export {
+  createOwnershipTransferCaveatBuilder,
+  type OwnershipUnitOfAuthorityConfig,
+} from './ownershipUnitOfAuthority';
+
+export {
+  createFunctionCallCaveatBuilder,
+  type FunctionCallUnitOfAuthorityConfig,
+} from './functionCallUnitOfAuthority';

--- a/packages/delegation-toolkit/src/caveatBuilder/limitedCallsBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/limitedCallsBuilder.ts
@@ -4,18 +4,24 @@ import type { DeleGatorEnvironment, Caveat } from '../types';
 
 export const limitedCalls = 'limitedCalls';
 
+export type LimitedCallsBuilderConfig = {
+  limit: number;
+};
+
 /**
  * Builds a caveat struct for the LimitedCallsEnforcer.
  *
  * @param environment - The DeleGator environment.
- * @param limit - The maximum number of calls allowed.
+ * @param config - The configuration object containing the limit.
  * @returns The Caveat.
  * @throws Error if the limit is not a positive integer.
  */
 export const limitedCallsBuilder = (
   environment: DeleGatorEnvironment,
-  limit: number,
+  config: LimitedCallsBuilderConfig,
 ): Caveat => {
+  const { limit } = config;
+
   if (!Number.isInteger(limit)) {
     throw new Error('Invalid limit: must be an integer');
   }

--- a/packages/delegation-toolkit/src/caveatBuilder/multiTokenPeriodBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/multiTokenPeriodBuilder.ts
@@ -10,6 +10,8 @@ export type TokenPeriodConfig = {
   startDate: number;
 };
 
+export type MultiTokenPeriodBuilderConfig = TokenPeriodConfig[];
+
 export const multiTokenPeriod = 'multiTokenPeriod';
 
 /**
@@ -18,12 +20,12 @@ export const multiTokenPeriod = 'multiTokenPeriod';
  * Each token can have its own period amount, duration, and start date.
  *
  * @param environment - The DeleGator environment.
- * @param configs - Array of token period configurations.
+ * @param configs - The configurations for the MultiTokenPeriodBuilder.
  * @returns The caveat object for the MultiTokenPeriodEnforcer.
  */
 export const multiTokenPeriodBuilder = (
   environment: DeleGatorEnvironment,
-  configs: TokenPeriodConfig[],
+  configs: MultiTokenPeriodBuilderConfig,
 ): Caveat => {
   if (!configs || configs.length === 0) {
     throw new Error('MultiTokenPeriodBuilder: configs array cannot be empty');

--- a/packages/delegation-toolkit/src/caveatBuilder/nativeBalanceChangeBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/nativeBalanceChangeBuilder.ts
@@ -5,22 +5,26 @@ import { BalanceChangeType } from './types';
 
 export const nativeBalanceChange = 'nativeBalanceChange';
 
+export type NativeBalanceChangeBuilderConfig = {
+  recipient: Address;
+  balance: bigint;
+  changeType: BalanceChangeType;
+};
+
 /**
  * Builds a caveat struct for the NativeBalanceChangeEnforcer.
  *
  * @param environment - The DeleGator environment.
- * @param recipient - The address that should receive the balance change.
- * @param balance - The minimum balance amount required.
- * @param changeType - Whether the balance should increase or decrease.
+ * @param config - The configuration object for the NativeBalanceChangeEnforcer.
  * @returns The Caveat.
  * @throws Error if the recipient address is invalid or the amount is not a positive number.
  */
 export const nativeBalanceChangeBuilder = (
   environment: DeleGatorEnvironment,
-  recipient: Address,
-  balance: bigint,
-  changeType: BalanceChangeType,
+  config: NativeBalanceChangeBuilderConfig,
 ): Caveat => {
+  const { recipient, balance, changeType } = config;
+
   if (!isAddress(recipient)) {
     throw new Error('Invalid recipient: must be a valid Address');
   }

--- a/packages/delegation-toolkit/src/caveatBuilder/nativeTokenPaymentBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/nativeTokenPaymentBuilder.ts
@@ -1,23 +1,28 @@
-import { type Hex, encodePacked, isAddress } from 'viem';
+import { type Address, encodePacked, isAddress } from 'viem';
 
 import type { Caveat, DeleGatorEnvironment } from '../types';
 
 export const nativeTokenPayment = 'nativeTokenPayment';
 
+export type NativeTokenPaymentBuilderConfig = {
+  recipient: Address;
+  amount: bigint;
+};
+
 /**
  * Builds a caveat struct for the NativeTokenPaymentEnforcer.
  *
  * @param environment - The DeleGator environment.
- * @param recipient - The address of the recipient of the payment.
- * @param amount - The amount of native tokens required for the payment.
+ * @param config - The configuration object for the NativeTokenPaymentEnforcer.
  * @returns The Caveat.
  * @throws Error if the amount is invalid or the recipient address is invalid.
  */
 export const nativeTokenPaymentBuilder = (
   environment: DeleGatorEnvironment,
-  recipient: Hex,
-  amount: bigint,
+  config: NativeTokenPaymentBuilderConfig,
 ): Caveat => {
+  const { recipient, amount } = config;
+
   if (amount <= 0n) {
     throw new Error('Invalid amount: must be positive');
   }

--- a/packages/delegation-toolkit/src/caveatBuilder/nativeTokenPeriodTransferBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/nativeTokenPeriodTransferBuilder.ts
@@ -4,6 +4,12 @@ import type { Caveat, DeleGatorEnvironment } from '../types';
 
 export const nativeTokenPeriodTransfer = 'nativeTokenPeriodTransfer';
 
+export type NativeTokenPeriodTransferBuilderConfig = {
+  periodAmount: bigint;
+  periodDuration: number;
+  startDate: number;
+};
+
 /**
  * Builds a caveat struct for NativeTokenPeriodTransferEnforcer.
  * This enforcer validates that native token (ETH) transfers do not exceed a specified amount
@@ -11,18 +17,16 @@ export const nativeTokenPeriodTransfer = 'nativeTokenPeriodTransfer';
  * and any unused ETH is forfeited once the period ends.
  *
  * @param environment - The DeleGator environment.
- * @param periodAmount - The maximum amount of ETH (in wei) that can be transferred per period.
- * @param periodDuration - The duration of each period in seconds.
- * @param startDate - The timestamp when the first period begins.
+ * @param config - The configuration object containing periodAmount, periodDuration, and startDate.
  * @returns The Caveat.
  * @throws Error if any of the parameters are invalid.
  */
 export const nativeTokenPeriodTransferBuilder = (
   environment: DeleGatorEnvironment,
-  periodAmount: bigint,
-  periodDuration: number,
-  startDate: number,
+  config: NativeTokenPeriodTransferBuilderConfig,
 ): Caveat => {
+  const { periodAmount, periodDuration, startDate } = config;
+
   const terms = createNativeTokenPeriodTransferTerms({
     periodAmount,
     periodDuration,

--- a/packages/delegation-toolkit/src/caveatBuilder/nativeTokenStreamingBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/nativeTokenStreamingBuilder.ts
@@ -4,24 +4,27 @@ import type { DeleGatorEnvironment, Caveat } from '../types';
 
 export const nativeTokenStreaming = 'nativeTokenStreaming';
 
+export type NativeTokenStreamingBuilderConfig = {
+  initialAmount: bigint;
+  maxAmount: bigint;
+  amountPerSecond: bigint;
+  startTime: number;
+};
+
 /**
  * Builds a caveat struct for the NativeTokenStreamingEnforcer.
  *
  * @param environment - The DeleGator environment.
- * @param initialAmount - The initial amount of tokens to release at start time.
- * @param maxAmount - The maximum amount of tokens that can be released.
- * @param amountPerSecond - The rate at which the allowance increases per second.
- * @param startTime - The timestamp from which the allowance streaming begins.
+ * @param config - The configuration object for the NativeTokenStreamingEnforcer.
  * @returns The Caveat.
  * @throws Error if any of the parameters are invalid.
  */
 export const nativeTokenStreamingBuilder = (
   environment: DeleGatorEnvironment,
-  initialAmount: bigint,
-  maxAmount: bigint,
-  amountPerSecond: bigint,
-  startTime: number,
+  config: NativeTokenStreamingBuilderConfig,
 ): Caveat => {
+  const { initialAmount, maxAmount, amountPerSecond, startTime } = config;
+
   const terms = createNativeTokenStreamingTerms({
     initialAmount,
     maxAmount,

--- a/packages/delegation-toolkit/src/caveatBuilder/nativeTokenTransferAmountBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/nativeTokenTransferAmountBuilder.ts
@@ -4,23 +4,29 @@ import type { Caveat, DeleGatorEnvironment } from '../types';
 
 export const nativeTokenTransferAmount = 'nativeTokenTransferAmount';
 
+export type NativeTokenTransferAmountBuilderConfig = {
+  maxAmount: bigint;
+};
+
 /**
  * Builds a caveat struct for the NativeTokenTransferAmountEnforcer.
  *
  * @param environment - The DeleGator environment.
- * @param allowance - The maximum amount of native tokens allowed (in wei).
+ * @param config - The configuration object containing the maxAmount.
  * @returns The Caveat.
- * @throws Error if the allowance is negative.
+ * @throws Error if the maxAmount is negative.
  */
 export const nativeTokenTransferAmountBuilder = (
   environment: DeleGatorEnvironment,
-  allowance: bigint,
+  config: NativeTokenTransferAmountBuilderConfig,
 ): Caveat => {
-  if (allowance < 0n) {
-    throw new Error('Invalid allowance: must be zero or positive');
+  const { maxAmount } = config;
+
+  if (maxAmount < 0n) {
+    throw new Error('Invalid maxAmount: must be zero or positive');
   }
 
-  const terms = encodePacked(['uint256'], [allowance]);
+  const terms = encodePacked(['uint256'], [maxAmount]);
 
   const {
     caveatEnforcers: { NativeTokenTransferAmountEnforcer },

--- a/packages/delegation-toolkit/src/caveatBuilder/nativeTokenUnitOfAuthority.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/nativeTokenUnitOfAuthority.ts
@@ -1,9 +1,9 @@
-import type { UnitOfAuthorityBaseConfig } from './types';
 import { createCaveatBuilder } from './coreCaveatBuilder';
 import type { CoreCaveatBuilder } from './coreCaveatBuilder';
-import { NativeTokenPeriodTransferBuilderConfig } from './nativeTokenPeriodTransferBuilder';
-import { NativeTokenStreamingBuilderConfig } from './nativeTokenStreamingBuilder';
-import { NativeTokenTransferAmountBuilderConfig } from './nativeTokenTransferAmountBuilder';
+import type { NativeTokenPeriodTransferBuilderConfig } from './nativeTokenPeriodTransferBuilder';
+import type { NativeTokenStreamingBuilderConfig } from './nativeTokenStreamingBuilder';
+import type { NativeTokenTransferAmountBuilderConfig } from './nativeTokenTransferAmountBuilder';
+import type { UnitOfAuthorityBaseConfig } from './types';
 
 export type NativeTokenUnitOfAuthorityConfig = UnitOfAuthorityBaseConfig &
   (
@@ -12,12 +12,37 @@ export type NativeTokenUnitOfAuthorityConfig = UnitOfAuthorityBaseConfig &
     | NativeTokenPeriodTransferBuilderConfig
   );
 
+const isNativeTokenStreamingConfig = (
+  config: NativeTokenUnitOfAuthorityConfig,
+): config is NativeTokenStreamingBuilderConfig & UnitOfAuthorityBaseConfig => {
+  return (
+    'initialAmount' in config &&
+    'maxAmount' in config &&
+    'amountPerSecond' in config &&
+    'startTime' in config
+  );
+};
+
+const isNativeTokenTransferAmountConfig = (
+  config: NativeTokenUnitOfAuthorityConfig,
+): config is NativeTokenTransferAmountBuilderConfig &
+  UnitOfAuthorityBaseConfig => {
+  return 'maxAmount' in config;
+};
+
+const isNativeTokenPeriodTransferConfig = (
+  config: NativeTokenUnitOfAuthorityConfig,
+): config is NativeTokenPeriodTransferBuilderConfig &
+  UnitOfAuthorityBaseConfig => {
+  return (
+    'periodAmount' in config &&
+    'periodDuration' in config &&
+    'startDate' in config
+  );
+};
+
 /**
  * Creates a caveat builder configured for native token streaming with value limits.
- *
- * This function creates a caveat builder that includes:
- * - A native token streaming caveat with the specified token parameters
- * - A value limit caveat that restricts the total value to 0 (preventing native token transfers)
  *
  * @param config - Configuration object containing environment and native token streaming parameters.
  * @param config.environment - The DeleGator environment.
@@ -54,32 +79,3 @@ export function createNativeTokenCaveatBuilder(
 
   return caveatBuilder;
 }
-
-const isNativeTokenStreamingConfig = (
-  config: NativeTokenUnitOfAuthorityConfig,
-): config is NativeTokenStreamingBuilderConfig & UnitOfAuthorityBaseConfig => {
-  return (
-    'initialAmount' in config &&
-    'maxAmount' in config &&
-    'amountPerSecond' in config &&
-    'startTime' in config
-  );
-};
-
-const isNativeTokenTransferAmountConfig = (
-  config: NativeTokenUnitOfAuthorityConfig,
-): config is NativeTokenTransferAmountBuilderConfig &
-  UnitOfAuthorityBaseConfig => {
-  return 'maxAmount' in config;
-};
-
-const isNativeTokenPeriodTransferConfig = (
-  config: NativeTokenUnitOfAuthorityConfig,
-): config is NativeTokenPeriodTransferBuilderConfig &
-  UnitOfAuthorityBaseConfig => {
-  return (
-    'periodAmount' in config &&
-    'periodDuration' in config &&
-    'startDate' in config
-  );
-};

--- a/packages/delegation-toolkit/src/caveatBuilder/nativeTokenUnitOfAuthority.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/nativeTokenUnitOfAuthority.ts
@@ -1,0 +1,85 @@
+import type { UnitOfAuthorityBaseConfig } from './types';
+import { createCaveatBuilder } from './coreCaveatBuilder';
+import type { CoreCaveatBuilder } from './coreCaveatBuilder';
+import { NativeTokenPeriodTransferBuilderConfig } from './nativeTokenPeriodTransferBuilder';
+import { NativeTokenStreamingBuilderConfig } from './nativeTokenStreamingBuilder';
+import { NativeTokenTransferAmountBuilderConfig } from './nativeTokenTransferAmountBuilder';
+
+export type NativeTokenUnitOfAuthorityConfig = UnitOfAuthorityBaseConfig &
+  (
+    | NativeTokenStreamingBuilderConfig
+    | NativeTokenTransferAmountBuilderConfig
+    | NativeTokenPeriodTransferBuilderConfig
+  );
+
+/**
+ * Creates a caveat builder configured for native token streaming with value limits.
+ *
+ * This function creates a caveat builder that includes:
+ * - A native token streaming caveat with the specified token parameters
+ * - A value limit caveat that restricts the total value to 0 (preventing native token transfers)
+ *
+ * @param config - Configuration object containing environment and native token streaming parameters.
+ * @param config.environment - The DeleGator environment.
+ * @param config.tokenAddress - The address of the native token to stream.
+ * @param config.initialAmount - The initial amount of tokens available immediately.
+ * @param config.maxAmount - The maximum total amount of tokens that can be streamed.
+ * @param config.amountPerSecond - The rate at which allowance increases per second.
+ * @param config.startTime - The Unix timestamp when streaming begins.
+ * @returns A configured caveat builder with native token streaming and value limit caveats.
+ * @throws Error if any of the native token streaming parameters are invalid.
+ * @throws Error if the environment is not properly configured.
+ */
+export function createNativeTokenCaveatBuilder(
+  config: NativeTokenUnitOfAuthorityConfig,
+): CoreCaveatBuilder {
+  const { environment } = config;
+
+  const caveatBuilder = createCaveatBuilder(environment).addCaveat(
+    'exactCalldata',
+    {
+      calldata: '0x',
+    },
+  );
+
+  if (isNativeTokenStreamingConfig(config)) {
+    caveatBuilder.addCaveat('nativeTokenStreaming', config);
+  } else if (isNativeTokenPeriodTransferConfig(config)) {
+    caveatBuilder.addCaveat('nativeTokenPeriodTransfer', config);
+  } else if (isNativeTokenTransferAmountConfig(config)) {
+    caveatBuilder.addCaveat('nativeTokenTransferAmount', config);
+  } else {
+    throw new Error('Invalid native token configuration');
+  }
+
+  return caveatBuilder;
+}
+
+const isNativeTokenStreamingConfig = (
+  config: NativeTokenUnitOfAuthorityConfig,
+): config is NativeTokenStreamingBuilderConfig & UnitOfAuthorityBaseConfig => {
+  return (
+    'initialAmount' in config &&
+    'maxAmount' in config &&
+    'amountPerSecond' in config &&
+    'startTime' in config
+  );
+};
+
+const isNativeTokenTransferAmountConfig = (
+  config: NativeTokenUnitOfAuthorityConfig,
+): config is NativeTokenTransferAmountBuilderConfig &
+  UnitOfAuthorityBaseConfig => {
+  return 'maxAmount' in config;
+};
+
+const isNativeTokenPeriodTransferConfig = (
+  config: NativeTokenUnitOfAuthorityConfig,
+): config is NativeTokenPeriodTransferBuilderConfig &
+  UnitOfAuthorityBaseConfig => {
+  return (
+    'periodAmount' in config &&
+    'periodDuration' in config &&
+    'startDate' in config
+  );
+};

--- a/packages/delegation-toolkit/src/caveatBuilder/nonceBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/nonceBuilder.ts
@@ -7,18 +7,24 @@ export const nonce = 'nonce';
 // char length of 32 byte hex string
 const MAX_NONCE_STRING_LENGTH = 66;
 
+export type NonceBuilderConfig = {
+  nonceValue: Hex;
+};
+
 /**
  * Builds a caveat struct for the NonceEnforcer.
  *
  * @param environment - The DeleGator environment.
- * @param nonceValue - The nonce value as a hexadecimal string.
+ * @param config - The configuration object containing the nonce value.
  * @returns The Caveat.
  * @throws Error if the nonce is invalid.
  */
 export const nonceBuilder = (
   environment: DeleGatorEnvironment,
-  nonceValue: Hex,
+  config: NonceBuilderConfig,
 ): Caveat => {
+  const { nonceValue } = config;
+
   if (!nonceValue || nonceValue === '0x') {
     throw new Error('Invalid nonce: must be a non-empty hex string');
   }
@@ -31,6 +37,8 @@ export const nonceBuilder = (
     throw new Error('Invalid nonce: must be 32 bytes or less in length');
   }
 
+  const terms = pad(nonceValue, { size: 32 });
+
   const {
     caveatEnforcers: { NonceEnforcer },
   } = environment;
@@ -41,7 +49,7 @@ export const nonceBuilder = (
 
   return {
     enforcer: NonceEnforcer,
-    terms: pad(nonceValue, { size: 32 }),
+    terms,
     args: '0x',
   };
 };

--- a/packages/delegation-toolkit/src/caveatBuilder/ownershipTransferBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/ownershipTransferBuilder.ts
@@ -4,18 +4,24 @@ import type { DeleGatorEnvironment, Caveat } from '../types';
 
 export const ownershipTransfer = 'ownershipTransfer';
 
+export type OwnershipTransferBuilderConfig = {
+  targetContract: Address;
+};
+
 /**
  * Builds a caveat struct for the OwnershipTransferEnforcer.
  *
  * @param environment - The DeleGator environment.
- * @param targetContract - The target contract address for the ownership transfer.
+ * @param config - The configuration object for the ownership transfer builder.
  * @returns The Caveat representing the caveat for ownership transfer.
  * @throws Error if the target contract address is invalid.
  */
 export const ownershipTransferBuilder = (
   environment: DeleGatorEnvironment,
-  targetContract: Address,
+  config: OwnershipTransferBuilderConfig,
 ): Caveat => {
+  const { targetContract } = config;
+
   if (!isAddress(targetContract, { strict: false })) {
     throw new Error('Invalid targetContract: must be a valid address');
   }

--- a/packages/delegation-toolkit/src/caveatBuilder/ownershipUnitOfAuthority.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/ownershipUnitOfAuthority.ts
@@ -1,0 +1,39 @@
+import type { DeleGatorEnvironment } from '../types';
+import { createCaveatBuilder } from './coreCaveatBuilder';
+import type { CoreCaveatBuilder } from './coreCaveatBuilder';
+import type { OwnershipTransferBuilderConfig } from './ownershipTransferBuilder';
+
+export type OwnershipUnitOfAuthorityConfig = OwnershipTransferBuilderConfig;
+
+/**
+ * Creates a caveat builder configured for ownership transfer unit of authority.
+ *
+ * This function creates a caveat builder that includes:
+ * - Ownership transfer caveat
+ *
+ * @param config - Configuration object containing the target contract.
+ * @param config.environment - The DeleGator environment.
+ * @returns A configured caveat builder with the specified caveats.
+ * @throws Error if any of the required parameters are invalid.
+ */
+export function createOwnershipTransferCaveatBuilder(
+  environment: DeleGatorEnvironment,
+  config: OwnershipUnitOfAuthorityConfig,
+): CoreCaveatBuilder {
+  if (!isOwnershipTransferConfig(config)) {
+    throw new Error('Invalid ownership transfer configuration');
+  }
+
+  const caveatBuilder = createCaveatBuilder(environment).addCaveat(
+    'ownershipTransfer',
+    config,
+  );
+
+  return caveatBuilder;
+}
+
+const isOwnershipTransferConfig = (
+  config: OwnershipUnitOfAuthorityConfig,
+): config is OwnershipTransferBuilderConfig => {
+  return 'targetContract' in config;
+};

--- a/packages/delegation-toolkit/src/caveatBuilder/ownershipUnitOfAuthority.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/ownershipUnitOfAuthority.ts
@@ -5,12 +5,16 @@ import type { OwnershipTransferBuilderConfig } from './ownershipTransferBuilder'
 
 export type OwnershipUnitOfAuthorityConfig = OwnershipTransferBuilderConfig;
 
+const isOwnershipTransferConfig = (
+  config: OwnershipUnitOfAuthorityConfig,
+): config is OwnershipTransferBuilderConfig => {
+  return 'targetContract' in config;
+};
+
 /**
  * Creates a caveat builder configured for ownership transfer unit of authority.
  *
- * This function creates a caveat builder that includes:
- * - Ownership transfer caveat
- *
+ * @param environment - The DeleGator environment.
  * @param config - Configuration object containing the target contract.
  * @param config.environment - The DeleGator environment.
  * @returns A configured caveat builder with the specified caveats.
@@ -31,9 +35,3 @@ export function createOwnershipTransferCaveatBuilder(
 
   return caveatBuilder;
 }
-
-const isOwnershipTransferConfig = (
-  config: OwnershipUnitOfAuthorityConfig,
-): config is OwnershipTransferBuilderConfig => {
-  return 'targetContract' in config;
-};

--- a/packages/delegation-toolkit/src/caveatBuilder/redeemerBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/redeemerBuilder.ts
@@ -4,18 +4,24 @@ import type { Caveat, DeleGatorEnvironment } from '../types';
 
 export const redeemer = 'redeemer';
 
+export type RedeemerBuilderConfig = {
+  redeemers: Address[];
+};
+
 /**
  * Builds a caveat struct for the RedeemerEnforcer.
  *
  * @param environment - The DeleGator environment.
- * @param redeemers - The addresses which will be allowed as redeemers.
+ * @param config - The configuration object containing redeemers.
  * @returns The Caveat.
  * @throws Error if the redeemer address is invalid or the array is empty.
  */
 export const redeemerBuilder = (
   environment: DeleGatorEnvironment,
-  redeemers: Address[],
+  config: RedeemerBuilderConfig,
 ): Caveat => {
+  const { redeemers } = config;
+
   if (redeemers.length === 0) {
     throw new Error(
       'Invalid redeemers: must specify at least one redeemer address',

--- a/packages/delegation-toolkit/src/caveatBuilder/resolveCaveats.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/resolveCaveats.ts
@@ -1,0 +1,48 @@
+import { createCaveatBuilderFromScope, type ScopeConfig } from './scope';
+
+import type { CoreCaveatConfiguration } from './coreCaveatBuilder';
+import type { CaveatBuilder } from './caveatBuilder';
+import { Caveat, DeleGatorEnvironment } from '../types';
+
+export type Caveats = CaveatBuilder | (Caveat | CoreCaveatConfiguration)[];
+
+/**
+ * Resolves the array of Caveat from a Caveats argument.
+ * @param config - The configuration for the caveat builder.
+ * @param config.environment - The environment to be used for the caveat builder.
+ * @param config.scope - The scope to be used for the caveat builder.
+ * @param config.caveats - The caveats to be resolved, which can be either a CaveatBuilder or an array of Caveat or CaveatConfiguration.
+ * @returns The resolved array of caveats.
+ */
+export const resolveCaveats = ({
+  environment,
+  scope,
+  caveats,
+}: {
+  environment: DeleGatorEnvironment;
+  scope: ScopeConfig;
+  caveats: Caveats;
+}) => {
+  const scopeCaveatBuilder = createCaveatBuilderFromScope(environment, scope);
+
+  if ('build' in caveats) {
+    (caveats as CaveatBuilder).build().forEach((caveat) => {
+      scopeCaveatBuilder.addCaveat(caveat);
+    });
+  } else if (Array.isArray(caveats)) {
+    caveats.forEach((caveat) => {
+      try {
+        if ('type' in caveat) {
+          const { type, ...config } = caveat as CoreCaveatConfiguration;
+          scopeCaveatBuilder.addCaveat(type, config);
+        } else {
+          scopeCaveatBuilder.addCaveat(caveat as Caveat);
+        }
+      } catch (error) {
+        throw new Error(`Invalid caveat: ${error}`);
+      }
+    });
+  }
+
+  return scopeCaveatBuilder.build();
+};

--- a/packages/delegation-toolkit/src/caveatBuilder/resolveCaveats.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/resolveCaveats.ts
@@ -1,8 +1,7 @@
-import { createCaveatBuilderFromScope, type ScopeConfig } from './scope';
-
-import type { CoreCaveatConfiguration } from './coreCaveatBuilder';
 import type { CaveatBuilder } from './caveatBuilder';
-import { Caveat, DeleGatorEnvironment } from '../types';
+import type { CoreCaveatConfiguration } from './coreCaveatBuilder';
+import { createCaveatBuilderFromScope, type ScopeConfig } from './scope';
+import type { Caveat, DeleGatorEnvironment } from '../types';
 
 export type Caveats = CaveatBuilder | (Caveat | CoreCaveatConfiguration)[];
 
@@ -33,13 +32,13 @@ export const resolveCaveats = ({
     caveats.forEach((caveat) => {
       try {
         if ('type' in caveat) {
-          const { type, ...config } = caveat as CoreCaveatConfiguration;
+          const { type, ...config } = caveat;
           scopeCaveatBuilder.addCaveat(type, config);
         } else {
-          scopeCaveatBuilder.addCaveat(caveat as Caveat);
+          scopeCaveatBuilder.addCaveat(caveat);
         }
       } catch (error) {
-        throw new Error(`Invalid caveat: ${error}`);
+        throw new Error(`Invalid caveat: ${(error as Error).message}`);
       }
     });
   }

--- a/packages/delegation-toolkit/src/caveatBuilder/scope/erc20Scope.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/scope/erc20Scope.ts
@@ -1,14 +1,18 @@
-import { createCaveatBuilder } from './coreCaveatBuilder';
-import type { CoreCaveatBuilder } from './coreCaveatBuilder';
-import type { Erc20PeriodTransferBuilderConfig } from './erc20PeriodTransferBuilder';
-import type { Erc20StreamingBuilderConfig } from './erc20StreamingBuilder';
-import type { Erc20TransferAmountBuilderConfig } from './erc20TransferAmountBuilder';
-import type { SpecificActionErc20TransferBatchBuilderConfig } from './specificActionERC20TransferBatchBuilder';
-import type { UnitOfAuthorityBaseConfig } from './types';
+import { createCaveatBuilder } from '../coreCaveatBuilder';
+import type { CoreCaveatBuilder } from '../coreCaveatBuilder';
+import type { Erc20PeriodTransferBuilderConfig } from '../erc20PeriodTransferBuilder';
+import type { Erc20StreamingBuilderConfig } from '../erc20StreamingBuilder';
+import type { Erc20TransferAmountBuilderConfig } from '../erc20TransferAmountBuilder';
+import type { SpecificActionErc20TransferBatchBuilderConfig } from '../specificActionERC20TransferBatchBuilder';
+import type { DeleGatorEnvironment } from 'src/types';
+
+type Erc20ScopeBaseConfig = {
+  type: 'erc20';
+};
 
 const isErc20StreamingConfig = (
-  config: Erc20UnitOfAuthorityConfig,
-): config is Erc20StreamingBuilderConfig & UnitOfAuthorityBaseConfig => {
+  config: Erc20ScopeBaseConfig,
+): config is Erc20StreamingBuilderConfig & Erc20ScopeBaseConfig => {
   return (
     'initialAmount' in config &&
     'maxAmount' in config &&
@@ -18,14 +22,14 @@ const isErc20StreamingConfig = (
 };
 
 const isErc20TransferAmountConfig = (
-  config: Erc20UnitOfAuthorityConfig,
-): config is Erc20TransferAmountBuilderConfig & UnitOfAuthorityBaseConfig => {
+  config: Erc20ScopeBaseConfig,
+): config is Erc20TransferAmountBuilderConfig & Erc20ScopeBaseConfig => {
   return 'tokenAddress' in config && 'maxAmount' in config;
 };
 
 const isErc20PeriodTransferConfig = (
-  config: Erc20UnitOfAuthorityConfig,
-): config is Erc20PeriodTransferBuilderConfig & UnitOfAuthorityBaseConfig => {
+  config: Erc20ScopeBaseConfig,
+): config is Erc20PeriodTransferBuilderConfig & Erc20ScopeBaseConfig => {
   return (
     'tokenAddress' in config &&
     'periodAmount' in config &&
@@ -35,9 +39,9 @@ const isErc20PeriodTransferConfig = (
 };
 
 const isSpecificActionErc20TransferBatchConfig = (
-  config: Erc20UnitOfAuthorityConfig,
+  config: Erc20ScopeBaseConfig,
 ): config is SpecificActionErc20TransferBatchBuilderConfig &
-  UnitOfAuthorityBaseConfig => {
+  Erc20ScopeBaseConfig => {
   return (
     'tokenAddress' in config &&
     'recipient' in config &&
@@ -47,7 +51,7 @@ const isSpecificActionErc20TransferBatchConfig = (
   );
 };
 
-export type Erc20UnitOfAuthorityConfig = UnitOfAuthorityBaseConfig &
+export type Erc20ScopeConfig = Erc20ScopeBaseConfig &
   (
     | Erc20StreamingBuilderConfig
     | Erc20TransferAmountBuilderConfig
@@ -58,22 +62,16 @@ export type Erc20UnitOfAuthorityConfig = UnitOfAuthorityBaseConfig &
 /**
  * Creates a caveat builder configured for ERC20 token streaming with value limits.
  *
- * @param config - Configuration object containing environment and ERC20 streaming parameters.
- * @param config.environment - The DeleGator environment.
- * @param config.tokenAddress - The address of the ERC20 token to stream.
- * @param config.initialAmount - The initial amount of tokens available immediately.
- * @param config.maxAmount - The maximum total amount of tokens that can be streamed.
- * @param config.amountPerSecond - The rate at which allowance increases per second.
- * @param config.startTime - The Unix timestamp when streaming begins.
+ * @param environment - The DeleGator environment.
+ * @param config - Configuration object containing ERC20 streaming parameters.
  * @returns A configured caveat builder with ERC20 streaming and value limit caveats.
  * @throws Error if any of the ERC20 streaming parameters are invalid.
  * @throws Error if the environment is not properly configured.
  */
 export function createErc20CaveatBuilder(
-  config: Erc20UnitOfAuthorityConfig,
+  environment: DeleGatorEnvironment,
+  config: Erc20ScopeConfig,
 ): CoreCaveatBuilder {
-  const { environment } = config;
-
   const caveatBuilder = createCaveatBuilder(environment).addCaveat('valueLte', {
     maxValue: 0n,
   });

--- a/packages/delegation-toolkit/src/caveatBuilder/scope/erc721Scope.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/scope/erc721Scope.ts
@@ -1,33 +1,38 @@
-import { createCaveatBuilder } from './coreCaveatBuilder';
-import type { CoreCaveatBuilder } from './coreCaveatBuilder';
-import type { Erc721TransferBuilderConfig } from './erc721TransferBuilder';
-import type { UnitOfAuthorityBaseConfig } from './types';
+import { createCaveatBuilder } from '../coreCaveatBuilder';
+import type { CoreCaveatBuilder } from '../coreCaveatBuilder';
+import type { Erc721TransferBuilderConfig } from '../erc721TransferBuilder';
+import type { DeleGatorEnvironment } from 'src/types';
 
-export type Erc721UnitOfAuthorityConfig = UnitOfAuthorityBaseConfig &
+export type Erc721ScopeBaseConfig = {
+  type: 'erc721';
+};
+
+export type Erc721ScopeConfig = Erc721ScopeBaseConfig &
   Erc721TransferBuilderConfig;
 
 const isErc721TransferConfig = (
-  config: Erc721UnitOfAuthorityConfig,
-): config is Erc721UnitOfAuthorityConfig => {
+  config: Erc721ScopeBaseConfig,
+): config is Erc721TransferBuilderConfig & Erc721ScopeBaseConfig => {
   return 'permittedContract' in config && 'permittedTokenId' in config;
 };
 
 /**
  * Creates a caveat builder configured for ERC721 unit of authority.
  *
+ * @param environment - The DeleGator environment.
  * @param config - Configuration object containing permitted contract and token ID.
- * @param config.environment - The DeleGator environment.
  * @returns A configured caveat builder with the specified caveats.
  * @throws Error if any of the required parameters are invalid.
  */
 export function createErc721CaveatBuilder(
-  config: Erc721UnitOfAuthorityConfig,
+  environment: DeleGatorEnvironment,
+  config: Erc721ScopeConfig,
 ): CoreCaveatBuilder {
   if (!isErc721TransferConfig(config)) {
     throw new Error('Invalid ERC721 configuration');
   }
 
-  const caveatBuilder = createCaveatBuilder(config.environment).addCaveat(
+  const caveatBuilder = createCaveatBuilder(environment).addCaveat(
     'erc721Transfer',
     config,
   );

--- a/packages/delegation-toolkit/src/caveatBuilder/scope/functionCallScope.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/scope/functionCallScope.ts
@@ -1,12 +1,16 @@
-import type { AllowedCalldataBuilderConfig } from './allowedCalldataBuilder';
-import type { AllowedMethodsBuilderConfig } from './allowedMethodsBuilder';
-import type { AllowedTargetsBuilderConfig } from './allowedTargetsBuilder';
-import { createCaveatBuilder } from './coreCaveatBuilder';
-import type { CoreCaveatBuilder } from './coreCaveatBuilder';
-import type { ExactCalldataBuilderConfig } from './exactCalldataBuilder';
-import type { UnitOfAuthorityBaseConfig } from './types';
+import type { AllowedCalldataBuilderConfig } from '../allowedCalldataBuilder';
+import type { AllowedMethodsBuilderConfig } from '../allowedMethodsBuilder';
+import type { AllowedTargetsBuilderConfig } from '../allowedTargetsBuilder';
+import { createCaveatBuilder } from '../coreCaveatBuilder';
+import type { CoreCaveatBuilder } from '../coreCaveatBuilder';
+import type { ExactCalldataBuilderConfig } from '../exactCalldataBuilder';
+import type { DeleGatorEnvironment } from 'src/types';
 
-export type FunctionCallUnitOfAuthorityConfig = UnitOfAuthorityBaseConfig &
+type FunctionCallScopeBaseConfig = {
+  type: 'functionCall';
+};
+
+export type FunctionCallScopeConfig = FunctionCallScopeBaseConfig &
   AllowedTargetsBuilderConfig &
   AllowedMethodsBuilderConfig & {
     allowedCalldata?: AllowedCalldataBuilderConfig[];
@@ -14,24 +18,24 @@ export type FunctionCallUnitOfAuthorityConfig = UnitOfAuthorityBaseConfig &
   };
 
 const isFunctionCallConfig = (
-  config: FunctionCallUnitOfAuthorityConfig,
-): config is FunctionCallUnitOfAuthorityConfig => {
+  config: FunctionCallScopeConfig,
+): config is FunctionCallScopeConfig => {
   return 'targets' in config && 'selectors' in config;
 };
 
 /**
  * Creates a caveat builder configured for function call unit of authority.
  *
+ * @param environment - The DeleGator environment.
  * @param config - Configuration object containing allowed targets, methods, and optionally calldata.
- * @param config.environment - The DeleGator environment.
  * @returns A configured caveat builder with the specified caveats.
  * @throws Error if any of the required parameters are invalid.
  */
 export function createFunctionCallCaveatBuilder(
-  config: FunctionCallUnitOfAuthorityConfig,
+  environment: DeleGatorEnvironment,
+  config: FunctionCallScopeConfig,
 ): CoreCaveatBuilder {
-  const { environment, targets, selectors, allowedCalldata, exactCalldata } =
-    config;
+  const { targets, selectors, allowedCalldata, exactCalldata } = config;
 
   if (!isFunctionCallConfig(config)) {
     throw new Error('Invalid Function Call configuration');

--- a/packages/delegation-toolkit/src/caveatBuilder/scope/index.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/scope/index.ts
@@ -1,0 +1,33 @@
+import { type Erc20ScopeConfig, createErc20CaveatBuilder } from './erc20Scope';
+import {
+  type Erc721ScopeConfig,
+  createErc721CaveatBuilder,
+} from './erc721Scope';
+import type { FunctionCallScopeConfig } from './functionCallScope';
+import type { NativeTokenScopeConfig } from './nativeTokenScope';
+import type { OwnershipScopeConfig } from './ownershipScope';
+import type { DeleGatorEnvironment } from '../../types';
+
+export type ScopeConfig =
+  | Erc20ScopeConfig
+  | Erc721ScopeConfig
+  | NativeTokenScopeConfig
+  | OwnershipScopeConfig
+  | FunctionCallScopeConfig;
+
+export const createCaveatBuilderFromScope = (
+  environment: DeleGatorEnvironment,
+  scopeConfig: ScopeConfig,
+) => {
+  switch (scopeConfig.type) {
+    case 'erc20':
+      return createErc20CaveatBuilder(
+        environment,
+        scopeConfig as Erc20ScopeConfig,
+      );
+    case 'erc721':
+      return createErc721CaveatBuilder(environment, scopeConfig);
+    default:
+      throw new Error('Invalid scope type');
+  }
+};

--- a/packages/delegation-toolkit/src/caveatBuilder/scope/nativeTokenScope.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/scope/nativeTokenScope.ts
@@ -1,11 +1,15 @@
-import { createCaveatBuilder } from './coreCaveatBuilder';
-import type { CoreCaveatBuilder } from './coreCaveatBuilder';
-import type { NativeTokenPeriodTransferBuilderConfig } from './nativeTokenPeriodTransferBuilder';
-import type { NativeTokenStreamingBuilderConfig } from './nativeTokenStreamingBuilder';
-import type { NativeTokenTransferAmountBuilderConfig } from './nativeTokenTransferAmountBuilder';
-import type { UnitOfAuthorityBaseConfig } from './types';
+import { createCaveatBuilder } from '../coreCaveatBuilder';
+import type { CoreCaveatBuilder } from '../coreCaveatBuilder';
+import type { NativeTokenPeriodTransferBuilderConfig } from '../nativeTokenPeriodTransferBuilder';
+import type { NativeTokenStreamingBuilderConfig } from '../nativeTokenStreamingBuilder';
+import type { NativeTokenTransferAmountBuilderConfig } from '../nativeTokenTransferAmountBuilder';
+import type { DeleGatorEnvironment } from 'src/types';
 
-export type NativeTokenUnitOfAuthorityConfig = UnitOfAuthorityBaseConfig &
+type NativeTokenScopeBaseConfig = {
+  type: 'nativeToken';
+};
+
+export type NativeTokenScopeConfig = NativeTokenScopeBaseConfig &
   (
     | NativeTokenStreamingBuilderConfig
     | NativeTokenTransferAmountBuilderConfig
@@ -13,8 +17,8 @@ export type NativeTokenUnitOfAuthorityConfig = UnitOfAuthorityBaseConfig &
   );
 
 const isNativeTokenStreamingConfig = (
-  config: NativeTokenUnitOfAuthorityConfig,
-): config is NativeTokenStreamingBuilderConfig & UnitOfAuthorityBaseConfig => {
+  config: NativeTokenScopeConfig,
+): config is NativeTokenStreamingBuilderConfig & NativeTokenScopeBaseConfig => {
   return (
     'initialAmount' in config &&
     'maxAmount' in config &&
@@ -24,16 +28,16 @@ const isNativeTokenStreamingConfig = (
 };
 
 const isNativeTokenTransferAmountConfig = (
-  config: NativeTokenUnitOfAuthorityConfig,
+  config: NativeTokenScopeConfig,
 ): config is NativeTokenTransferAmountBuilderConfig &
-  UnitOfAuthorityBaseConfig => {
+  NativeTokenScopeBaseConfig => {
   return 'maxAmount' in config;
 };
 
 const isNativeTokenPeriodTransferConfig = (
-  config: NativeTokenUnitOfAuthorityConfig,
+  config: NativeTokenScopeConfig,
 ): config is NativeTokenPeriodTransferBuilderConfig &
-  UnitOfAuthorityBaseConfig => {
+  NativeTokenScopeBaseConfig => {
   return (
     'periodAmount' in config &&
     'periodDuration' in config &&
@@ -44,22 +48,16 @@ const isNativeTokenPeriodTransferConfig = (
 /**
  * Creates a caveat builder configured for native token streaming with value limits.
  *
- * @param config - Configuration object containing environment and native token streaming parameters.
- * @param config.environment - The DeleGator environment.
- * @param config.tokenAddress - The address of the native token to stream.
- * @param config.initialAmount - The initial amount of tokens available immediately.
- * @param config.maxAmount - The maximum total amount of tokens that can be streamed.
- * @param config.amountPerSecond - The rate at which allowance increases per second.
- * @param config.startTime - The Unix timestamp when streaming begins.
+ * @param environment - The DeleGator environment.
+ * @param config - Configuration object containing native token streaming parameters.
  * @returns A configured caveat builder with native token streaming and value limit caveats.
  * @throws Error if any of the native token streaming parameters are invalid.
  * @throws Error if the environment is not properly configured.
  */
 export function createNativeTokenCaveatBuilder(
-  config: NativeTokenUnitOfAuthorityConfig,
+  environment: DeleGatorEnvironment,
+  config: NativeTokenScopeConfig,
 ): CoreCaveatBuilder {
-  const { environment } = config;
-
   const caveatBuilder = createCaveatBuilder(environment).addCaveat(
     'exactCalldata',
     {

--- a/packages/delegation-toolkit/src/caveatBuilder/scope/ownershipScope.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/scope/ownershipScope.ts
@@ -1,13 +1,18 @@
-import type { DeleGatorEnvironment } from '../types';
-import { createCaveatBuilder } from './coreCaveatBuilder';
-import type { CoreCaveatBuilder } from './coreCaveatBuilder';
-import type { OwnershipTransferBuilderConfig } from './ownershipTransferBuilder';
+import type { DeleGatorEnvironment } from '../../types';
+import { createCaveatBuilder } from '../coreCaveatBuilder';
+import type { CoreCaveatBuilder } from '../coreCaveatBuilder';
+import type { OwnershipTransferBuilderConfig } from '../ownershipTransferBuilder';
 
-export type OwnershipUnitOfAuthorityConfig = OwnershipTransferBuilderConfig;
+type OwnershipScopeBaseConfig = {
+  type: 'ownership';
+};
+
+export type OwnershipScopeConfig = OwnershipScopeBaseConfig &
+  OwnershipTransferBuilderConfig;
 
 const isOwnershipTransferConfig = (
-  config: OwnershipUnitOfAuthorityConfig,
-): config is OwnershipTransferBuilderConfig => {
+  config: OwnershipScopeConfig,
+): config is OwnershipTransferBuilderConfig & OwnershipScopeBaseConfig => {
   return 'targetContract' in config;
 };
 
@@ -16,13 +21,12 @@ const isOwnershipTransferConfig = (
  *
  * @param environment - The DeleGator environment.
  * @param config - Configuration object containing the target contract.
- * @param config.environment - The DeleGator environment.
  * @returns A configured caveat builder with the specified caveats.
  * @throws Error if any of the required parameters are invalid.
  */
-export function createOwnershipTransferCaveatBuilder(
+export function createOwnershipCaveatBuilder(
   environment: DeleGatorEnvironment,
-  config: OwnershipUnitOfAuthorityConfig,
+  config: OwnershipScopeConfig,
 ): CoreCaveatBuilder {
   if (!isOwnershipTransferConfig(config)) {
     throw new Error('Invalid ownership transfer configuration');

--- a/packages/delegation-toolkit/src/caveatBuilder/specificActionERC20TransferBatchBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/specificActionERC20TransferBatchBuilder.ts
@@ -18,11 +18,12 @@ export type SpecificActionErc20TransferBatchBuilderConfig = {
  * Enforces a batch of exactly 2 transactions: a specific action followed by an ERC20 transfer.
  *
  * @param environment - The DeleGator environment.
- * @param tokenAddress - The address of the ERC20 token contract.
- * @param recipient - The address that will receive the tokens.
- * @param amount - The amount of tokens to transfer.
- * @param firstTarget - The target address for the first transaction.
- * @param firstCalldata - The calldata for the first transaction.
+ * @param config - The configuration object containing the token address, recipient, amount, first target, and first calldata.
+ * @param config.tokenAddress - The address of the ERC20 token contract.
+ * @param config.recipient - The address that will receive the tokens.
+ * @param config.amount - The amount of tokens to transfer.
+ * @param config.firstTarget - The target address for the first transaction.
+ * @param config.firstCalldata - The calldata for the first transaction.
  * @returns The Caveat.
  * @throws Error if any of the addresses are invalid or if the amount is not a positive number.
  */

--- a/packages/delegation-toolkit/src/caveatBuilder/specificActionERC20TransferBatchBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/specificActionERC20TransferBatchBuilder.ts
@@ -5,6 +5,14 @@ import type { Caveat, DeleGatorEnvironment } from '../types';
 export const specificActionERC20TransferBatch =
   'specificActionERC20TransferBatch';
 
+export type SpecificActionErc20TransferBatchBuilderConfig = {
+  tokenAddress: Address;
+  recipient: Address;
+  amount: bigint;
+  firstTarget: Address;
+  firstCalldata: Hex;
+};
+
 /**
  * Builds a caveat struct for SpecificActionERC20TransferBatchEnforcer.
  * Enforces a batch of exactly 2 transactions: a specific action followed by an ERC20 transfer.
@@ -20,12 +28,11 @@ export const specificActionERC20TransferBatch =
  */
 export const specificActionERC20TransferBatchBuilder = (
   environment: DeleGatorEnvironment,
-  tokenAddress: Address,
-  recipient: Address,
-  amount: bigint,
-  firstTarget: Address,
-  firstCalldata: Hex,
+  config: SpecificActionErc20TransferBatchBuilderConfig,
 ): Caveat => {
+  const { tokenAddress, recipient, amount, firstTarget, firstCalldata } =
+    config;
+
   if (!isAddress(tokenAddress, { strict: false })) {
     throw new Error('Invalid tokenAddress: must be a valid address');
   }

--- a/packages/delegation-toolkit/src/caveatBuilder/timestampBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/timestampBuilder.ts
@@ -4,20 +4,25 @@ import type { Caveat, DeleGatorEnvironment } from '../types';
 
 export const timestamp = 'timestamp';
 
+export type TimestampBuilderConfig = {
+  timestampAfterThreshold: number;
+  timestampBeforeThreshold: number;
+};
+
 /**
  * Builds a caveat struct for the TimestampEnforcer.
  *
  * @param environment - The DeleGator environment.
- * @param timestampAfterThreshold - The timestamp (in seconds) after which the delegation can be used.
- * @param timestampBeforeThreshold - The timestamp (in seconds) before which the delegation can be used.
+ * @param config - The configuration object for the TimestampEnforcer.
  * @returns The Caveat.
  * @throws Error if any of the parameters are invalid.
  */
 export const timestampBuilder = (
   environment: DeleGatorEnvironment,
-  timestampAfterThreshold: number,
-  timestampBeforeThreshold: number,
+  config: TimestampBuilderConfig,
 ): Caveat => {
+  const { timestampAfterThreshold, timestampBeforeThreshold } = config;
+
   const terms = createTimestampTerms({
     timestampAfterThreshold,
     timestampBeforeThreshold,

--- a/packages/delegation-toolkit/src/caveatBuilder/types.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/types.ts
@@ -1,8 +1,4 @@
-import type { DeleGatorEnvironment } from 'src/types';
-
 export enum BalanceChangeType {
   Increase = 0x0,
   Decrease = 0x1,
 }
-
-export type UnitOfAuthorityBaseConfig = { environment: DeleGatorEnvironment };

--- a/packages/delegation-toolkit/src/caveatBuilder/types.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/types.ts
@@ -1,4 +1,8 @@
+import { DeleGatorEnvironment } from 'src/types';
+
 export enum BalanceChangeType {
   Increase = 0x0,
   Decrease = 0x1,
 }
+
+export type UnitOfAuthorityBaseConfig = { environment: DeleGatorEnvironment };

--- a/packages/delegation-toolkit/src/caveatBuilder/types.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/types.ts
@@ -1,4 +1,4 @@
-import { DeleGatorEnvironment } from 'src/types';
+import type { DeleGatorEnvironment } from 'src/types';
 
 export enum BalanceChangeType {
   Increase = 0x0,

--- a/packages/delegation-toolkit/src/caveatBuilder/valueLteBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/valueLteBuilder.ts
@@ -4,18 +4,24 @@ import type { Caveat, DeleGatorEnvironment } from '../types';
 
 export const valueLte = 'valueLte';
 
+export type ValueLteBuilderConfig = {
+  maxValue: bigint;
+};
+
 /**
  * Builds a caveat struct for ValueLteEnforcer.
  *
  * @param environment - The DeleGator environment.
- * @param maxValue - The maximum value allowed for the transaction.
+ * @param config - The configuration object containing the maximum value allowed for the transaction.
  * @returns The Caveat.
  * @throws Error if any of the parameters are invalid.
  */
 export const valueLteBuilder = (
   environment: DeleGatorEnvironment,
-  maxValue: bigint,
+  config: ValueLteBuilderConfig,
 ): Caveat => {
+  const { maxValue } = config;
+
   const terms = createValueLteTerms({ maxValue });
 
   const {

--- a/packages/delegation-toolkit/src/delegation.ts
+++ b/packages/delegation-toolkit/src/delegation.ts
@@ -270,6 +270,7 @@ export const createOpenDelegation = (
  * @param params.chainId - The chain ID for the signature.
  * @param params.name - The name of the contract.
  * @param params.version - The version of the contract.
+ * @param params.allowInsecureUnrestrictedDelegation - Whether to allow insecure unrestricted delegation.
  * @returns The signed delegation.
  */
 export const signDelegation = async ({

--- a/packages/delegation-toolkit/src/delegation.ts
+++ b/packages/delegation-toolkit/src/delegation.ts
@@ -20,8 +20,9 @@ import type {
 } from 'viem';
 
 import { type Caveats, resolveCaveats } from './caveatBuilder';
+import type { ScopeConfig } from './caveatBuilder/scope';
 import { CAVEAT_ABI_TYPE_COMPONENTS } from './caveats';
-import type { Delegation } from './types';
+import type { Delegation, DeleGatorEnvironment } from './types';
 
 export {
   ANY_BENEFICIARY,
@@ -190,6 +191,8 @@ export const getDelegationHashOffchain = (input: Delegation): Hex => {
 
 type BaseCreateDelegationOptions = {
   from: Hex;
+  environment: DeleGatorEnvironment;
+  scope: ScopeConfig;
   caveats: Caveats;
   parentDelegation?: Delegation | Hex;
   salt?: Hex;

--- a/packages/delegation-toolkit/src/delegation.ts
+++ b/packages/delegation-toolkit/src/delegation.ts
@@ -193,6 +193,7 @@ type BaseCreateDelegationOptions = {
   caveats: Caveats;
   parentDelegation?: Delegation | Hex;
   salt?: Hex;
+  allowInsecureUnrestrictedDelegation?: boolean;
 };
 
 /**
@@ -236,7 +237,7 @@ export const createDelegation = (
     delegate: options.to,
     delegator: options.from,
     authority: resolveAuthority(options.parentDelegation),
-    caveats: resolveCaveats(options.caveats),
+    caveats: resolveCaveats(options),
     salt: options.salt ?? '0x',
     signature: '0x',
   };
@@ -254,7 +255,7 @@ export const createOpenDelegation = (
     delegate: ANY_BENEFICIARY,
     delegator: options.from,
     authority: resolveAuthority(options.parentDelegation),
-    caveats: resolveCaveats(options.caveats),
+    caveats: resolveCaveats(options),
     salt: options.salt ?? '0x',
     signature: '0x',
   };
@@ -278,6 +279,7 @@ export const signDelegation = async ({
   chainId,
   name = 'DelegationManager',
   version = '1',
+  allowInsecureUnrestrictedDelegation = false,
 }: {
   signer: WalletClient<Transport, Chain, Account>;
   delegation: Omit<Delegation, 'signature'>;
@@ -285,11 +287,21 @@ export const signDelegation = async ({
   chainId: number;
   name?: string;
   version?: string;
+  allowInsecureUnrestrictedDelegation?: boolean;
 }) => {
   const delegationStruct = toDelegationStruct({
     ...delegation,
     signature: '0x',
   });
+
+  if (
+    delegationStruct.caveats.length === 0 &&
+    !allowInsecureUnrestrictedDelegation
+  ) {
+    throw new Error(
+      'No caveats found. If you definitely want to sign a delegation without caveats, set `allowInsecureUnrestrictedDelegation` to `true`.',
+    );
+  }
 
   return signer.signTypedData({
     account: signer.account,

--- a/packages/delegation-toolkit/src/index.ts
+++ b/packages/delegation-toolkit/src/index.ts
@@ -42,7 +42,22 @@ export { createExecution } from './executions';
 
 export type { ExecutionStruct, CreateExecutionArgs } from './executions';
 
-export type { Caveats } from './caveatBuilder';
+export type {
+  Caveats,
+  Erc20UnitOfAuthorityConfig,
+  Erc721UnitOfAuthorityConfig,
+  NativeTokenUnitOfAuthorityConfig,
+  OwnershipUnitOfAuthorityConfig,
+  FunctionCallUnitOfAuthorityConfig,
+} from './caveatBuilder';
+
+export {
+  createErc20CaveatBuilder,
+  createErc721CaveatBuilder,
+  createNativeTokenCaveatBuilder,
+  createOwnershipTransferCaveatBuilder,
+  createFunctionCallCaveatBuilder,
+} from './caveatBuilder';
 
 export { createCaveat } from './caveats';
 

--- a/packages/delegation-toolkit/src/index.ts
+++ b/packages/delegation-toolkit/src/index.ts
@@ -42,9 +42,7 @@ export { createExecution } from './executions';
 
 export type { ExecutionStruct, CreateExecutionArgs } from './executions';
 
-export { createCaveatBuilder, CaveatBuilder } from './caveatBuilder';
-
-export type { Caveats, CaveatBuilderConfig } from './caveatBuilder';
+export type { Caveats } from './caveatBuilder';
 
 export { createCaveat } from './caveats';
 

--- a/packages/delegation-toolkit/src/index.ts
+++ b/packages/delegation-toolkit/src/index.ts
@@ -42,22 +42,7 @@ export { createExecution } from './executions';
 
 export type { ExecutionStruct, CreateExecutionArgs } from './executions';
 
-export type {
-  Caveats,
-  Erc20UnitOfAuthorityConfig,
-  Erc721UnitOfAuthorityConfig,
-  NativeTokenUnitOfAuthorityConfig,
-  OwnershipUnitOfAuthorityConfig,
-  FunctionCallUnitOfAuthorityConfig,
-} from './caveatBuilder';
-
-export {
-  createErc20CaveatBuilder,
-  createErc721CaveatBuilder,
-  createNativeTokenCaveatBuilder,
-  createOwnershipTransferCaveatBuilder,
-  createFunctionCallCaveatBuilder,
-} from './caveatBuilder';
+export type { Caveats } from './caveatBuilder';
 
 export { createCaveat } from './caveats';
 

--- a/packages/delegation-toolkit/src/utils/index.ts
+++ b/packages/delegation-toolkit/src/utils/index.ts
@@ -45,3 +45,5 @@ export {
 export type { CoreCaveatBuilder, CaveatBuilderConfig } from '../caveatBuilder';
 
 export { createCaveatBuilder, CaveatBuilder } from '../caveatBuilder';
+
+export type { Caveats } from '../caveatBuilder/resolveCaveats';

--- a/packages/delegation-toolkit/src/utils/index.ts
+++ b/packages/delegation-toolkit/src/utils/index.ts
@@ -42,4 +42,6 @@ export {
   deployDeleGatorEnvironment,
 } from '../delegatorEnvironment';
 
-export type { CoreCaveatBuilder } from '../caveatBuilder';
+export type { CoreCaveatBuilder, CaveatBuilderConfig } from '../caveatBuilder';
+
+export { createCaveatBuilder, CaveatBuilder } from '../caveatBuilder';

--- a/packages/delegation-toolkit/test/caveatBuilder/CaveatBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/CaveatBuilder.test.ts
@@ -27,18 +27,18 @@ describe('CaveatBuilder', () => {
     });
   });
 
-  describe('allowEmptyCaveats', () => {
+  describe('allowInsecureUnrestrictedDelegation', () => {
     it('should disallow empty caveats', () => {
       const builder = new CaveatBuilder({} as DeleGatorEnvironment);
 
       expect(() => builder.build()).to.throw(
-        'No caveats found. If you definitely want to create an empty caveat collection, set `allowEmptyCaveats`.',
+        'No caveats found. If you definitely want to create an empty caveat collection, set `allowInsecureUnrestrictedDelegation` to `true`.',
       );
     });
 
     it('should allow empty caveats', () => {
       const builder = new CaveatBuilder({} as DeleGatorEnvironment, {
-        allowEmptyCaveats: true,
+        allowInsecureUnrestrictedDelegation: true,
       });
 
       expect(() => builder.build()).to.not.throw();
@@ -46,7 +46,7 @@ describe('CaveatBuilder', () => {
 
     it('should allow empty caveats when extended', () => {
       const builder = new CaveatBuilder({} as DeleGatorEnvironment, {
-        allowEmptyCaveats: true,
+        allowInsecureUnrestrictedDelegation: true,
       }).extend('caveat', () => caveat1);
 
       expect(() => builder.build()).to.not.throw();

--- a/packages/delegation-toolkit/test/caveatBuilder/allowedCalldataBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/allowedCalldataBuilder.test.ts
@@ -13,7 +13,8 @@ describe('allowedCalldataBuilder()', () => {
   } as any as DeleGatorEnvironment;
 
   const buildWithParams = (dataStart: number, value: Hex) => {
-    return allowedCalldataBuilder(environment, dataStart, value);
+    const config = { startIndex: dataStart, value };
+    return allowedCalldataBuilder(environment, config);
   };
 
   describe('validation', () => {

--- a/packages/delegation-toolkit/test/caveatBuilder/allowedMethodsBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/allowedMethodsBuilder.test.ts
@@ -15,7 +15,8 @@ describe('allowedMethodsBuilder()', () => {
   } as any as DeleGatorEnvironment;
 
   const buildWithSelectors = (selectors: MethodSelector[]) => {
-    return allowedMethodsBuilder(environment, selectors);
+    const config = { selectors };
+    return allowedMethodsBuilder(environment, config);
   };
 
   describe('validation', () => {

--- a/packages/delegation-toolkit/test/caveatBuilder/allowedTargetsBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/allowedTargetsBuilder.test.ts
@@ -14,7 +14,8 @@ describe('allowedTargetsBuilder()', () => {
   } as any as DeleGatorEnvironment;
 
   const buildWithTargets = (targets: Address[]) => {
-    return allowedTargetsBuilder(environment, targets);
+    const config = { targets };
+    return allowedTargetsBuilder(environment, config);
   };
 
   describe('validation', () => {

--- a/packages/delegation-toolkit/test/caveatBuilder/argsEqualityCheckBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/argsEqualityCheckBuilder.test.ts
@@ -11,23 +11,24 @@ describe('argsEqualityCheckBuilder()', () => {
   } as any as DeleGatorEnvironment;
 
   const buildWithArgs = (args: Hex) => {
-    return argsEqualityCheckBuilder(environment, args);
+    const config = { expectedArgs: args };
+    return argsEqualityCheckBuilder(environment, config);
   };
 
   describe('validation', () => {
     it('should fail when args is not hex', () => {
       expect(() => buildWithArgs('not-hex' as Hex)).to.throw(
-        'Invalid args: must be a valid hex string',
+        'Invalid config: expectedArgs must be a valid hex string',
       );
     });
 
     it('should fail when args is not defined', () => {
       expect(() => buildWithArgs(undefined as any as Hex)).to.throw(
-        'Invalid args: must be a valid hex string',
+        'Invalid config: expectedArgs must be a valid hex string',
       );
 
       expect(() => buildWithArgs(null as any as Hex)).to.throw(
-        'Invalid args: must be a valid hex string',
+        'Invalid config: expectedArgs must be a valid hex string',
       );
     });
   });

--- a/packages/delegation-toolkit/test/caveatBuilder/blockNumberBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/blockNumberBuilder.test.ts
@@ -16,11 +16,11 @@ describe('blockNumberBuilder()', () => {
     blockAfterThreshold: bigint,
     blockBeforeThreshold: bigint,
   ) => {
-    return blockNumberBuilder(
-      environment,
+    const config = {
       blockAfterThreshold,
       blockBeforeThreshold,
-    );
+    };
+    return blockNumberBuilder(environment, config);
   };
 
   describe('validation', () => {

--- a/packages/delegation-toolkit/test/caveatBuilder/createCaveatBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/createCaveatBuilder.test.ts
@@ -41,13 +41,13 @@ describe('createCaveatBuilder()', () => {
       const builder = createCaveatBuilder(environment);
 
       expect(() => builder.build()).to.throw(
-        'No caveats found. If you definitely want to create an empty caveat collection, set `allowEmptyCaveats`.',
+        'No caveats found. If you definitely want to create an empty caveat collection, set `allowInsecureUnrestrictedDelegation` to `true`.',
       );
     });
 
     it('should allow empty caveats, when configured', () => {
       const builder = createCaveatBuilder(environment, {
-        allowEmptyCaveats: true,
+        allowInsecureUnrestrictedDelegation: true,
       });
 
       expect(() => builder.build()).to.not.throw();
@@ -391,7 +391,7 @@ describe('createCaveatBuilder()', () => {
     it("should add a 'nativeTokenPayment' caveat", () => {
       const builder = createCaveatBuilder(environment);
       const amount = 1000000000000000000n; // 1 ETH in wei
-      const recipient = randomAddress(true);
+      const recipient = randomAddress('lowercase');
 
       const caveats = builder
         .addCaveat('nativeTokenPayment', recipient, amount)

--- a/packages/delegation-toolkit/test/caveatBuilder/deployedBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/deployedBuilder.test.ts
@@ -18,7 +18,8 @@ describe('deployedBuilder()', () => {
     salt: Hex,
     bytecode: Hex,
   ) => {
-    return deployedBuilder(environment, contractAddress, salt, bytecode);
+    const config = { contractAddress, salt, bytecode };
+    return deployedBuilder(environment, config);
   };
 
   const validContractAddress = randomAddress();

--- a/packages/delegation-toolkit/test/caveatBuilder/erc1155BalanceChangeBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/erc1155BalanceChangeBuilder.test.ts
@@ -20,14 +20,8 @@ describe('erc1155BalanceChangeBuilder', () => {
     balance: bigint,
     changeType: BalanceChangeType,
   ) => {
-    return erc1155BalanceChangeBuilder(
-      environment,
-      tokenAddress,
-      recipient,
-      tokenId,
-      balance,
-      changeType,
-    );
+    const config = { tokenAddress, recipient, tokenId, balance, changeType };
+    return erc1155BalanceChangeBuilder(environment, config);
   };
 
   describe('validation', () => {

--- a/packages/delegation-toolkit/test/caveatBuilder/erc20BalanceChangeBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/erc20BalanceChangeBuilder.test.ts
@@ -19,13 +19,8 @@ describe('erc20BalanceChangeBuilder', () => {
     balance: bigint,
     changeType: BalanceChangeType,
   ) => {
-    return erc20BalanceChangeBuilder(
-      environment,
-      token,
-      recipient,
-      balance,
-      changeType,
-    );
+    const config = { tokenAddress: token, recipient, balance, changeType };
+    return erc20BalanceChangeBuilder(environment, config);
   };
 
   describe('validation', () => {

--- a/packages/delegation-toolkit/test/caveatBuilder/erc20PeriodTransferBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/erc20PeriodTransferBuilder.test.ts
@@ -20,13 +20,8 @@ describe('erc20PeriodTransferBuilder()', () => {
     periodDuration: number,
     startDate: number,
   ) => {
-    return erc20PeriodTransferBuilder(
-      environment,
-      tokenAddress,
-      periodAmount,
-      periodDuration,
-      startDate,
-    );
+    const config = { tokenAddress, periodAmount, periodDuration, startDate };
+    return erc20PeriodTransferBuilder(environment, config);
   };
 
   describe('validation', () => {

--- a/packages/delegation-toolkit/test/caveatBuilder/erc20StreamingBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/erc20StreamingBuilder.test.ts
@@ -21,14 +21,14 @@ describe('erc20StreamingBuilder()', () => {
     amountPerSecond: bigint,
     startTime: number,
   ) => {
-    return erc20StreamingBuilder(
-      environment,
+    const config = {
       tokenAddress,
       initialAmount,
       maxAmount,
       amountPerSecond,
       startTime,
-    );
+    };
+    return erc20StreamingBuilder(environment, config);
   };
 
   describe('validation', () => {

--- a/packages/delegation-toolkit/test/caveatBuilder/erc20TransferAmountBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/erc20TransferAmountBuilder.test.ts
@@ -14,7 +14,8 @@ describe('erc20TransferAmountBuilder()', () => {
   } as any as DeleGatorEnvironment;
 
   const buildWithParams = (tokenAddress: Address, maxAmount: bigint) => {
-    return erc20TransferAmountBuilder(environment, tokenAddress, maxAmount);
+    const config = { tokenAddress, maxAmount };
+    return erc20TransferAmountBuilder(environment, config);
   };
 
   describe('validation', () => {

--- a/packages/delegation-toolkit/test/caveatBuilder/erc20UnitOfAuthority.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/erc20UnitOfAuthority.test.ts
@@ -1,9 +1,10 @@
 import { expect } from 'chai';
+import { concat, toHex } from 'viem';
+
 import { createErc20CaveatBuilder } from '../../src/caveatBuilder/erc20UnitOfAuthority';
 import type { Erc20UnitOfAuthorityConfig } from '../../src/caveatBuilder/erc20UnitOfAuthority';
 import { randomAddress } from '../utils';
-import { DeleGatorEnvironment } from 'src';
-import { concat, toHex } from 'viem';
+import type { DeleGatorEnvironment } from 'src';
 
 describe('createErc20CaveatBuilder', () => {
   const environment = {

--- a/packages/delegation-toolkit/test/caveatBuilder/erc20UnitOfAuthority.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/erc20UnitOfAuthority.test.ts
@@ -1,0 +1,159 @@
+import { expect } from 'chai';
+import { createErc20CaveatBuilder } from '../../src/caveatBuilder/erc20UnitOfAuthority';
+import type { Erc20UnitOfAuthorityConfig } from '../../src/caveatBuilder/erc20UnitOfAuthority';
+import { randomAddress } from '../utils';
+import { DeleGatorEnvironment } from 'src';
+import { concat, toHex } from 'viem';
+
+describe('createErc20CaveatBuilder', () => {
+  const environment = {
+    caveatEnforcers: {
+      ValueLteEnforcer: randomAddress(),
+      ERC20StreamingEnforcer: randomAddress(),
+      ERC20PeriodTransferEnforcer: randomAddress(),
+      ERC20TransferAmountEnforcer: randomAddress(),
+      SpecificActionERC20TransferBatchEnforcer: randomAddress(),
+    },
+  } as unknown as DeleGatorEnvironment;
+
+  it('creates an ERC20 streaming CaveatBuilder', () => {
+    const config: Erc20UnitOfAuthorityConfig = {
+      environment,
+      tokenAddress: randomAddress(),
+      initialAmount: 1000n,
+      maxAmount: 10000n,
+      amountPerSecond: 1n,
+      startTime: Math.floor(Date.now() / 1000),
+    };
+
+    const caveatBuilder = createErc20CaveatBuilder(config);
+
+    const caveats = caveatBuilder.build();
+
+    expect(caveats).to.deep.equal([
+      {
+        enforcer: environment.caveatEnforcers.ValueLteEnforcer,
+        args: '0x',
+        terms:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+      },
+      {
+        enforcer: environment.caveatEnforcers.ERC20StreamingEnforcer,
+        args: '0x',
+        terms: concat([
+          config.tokenAddress,
+          toHex(config.initialAmount, { size: 32 }),
+          toHex(config.maxAmount, { size: 32 }),
+          toHex(config.amountPerSecond, { size: 32 }),
+          toHex(config.startTime, { size: 32 }),
+        ]),
+      },
+    ]);
+  });
+
+  it('creates an ERC20 period transfer CaveatBuilder', () => {
+    const config: Erc20UnitOfAuthorityConfig = {
+      environment,
+      tokenAddress: randomAddress(),
+      periodAmount: 1000n,
+      periodDuration: 1000,
+      startDate: Math.floor(Date.now() / 1000),
+    };
+
+    const caveatBuilder = createErc20CaveatBuilder(config);
+
+    const caveats = caveatBuilder.build();
+
+    expect(caveats).to.deep.equal([
+      {
+        enforcer: environment.caveatEnforcers.ValueLteEnforcer,
+        args: '0x',
+        terms:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+      },
+      {
+        enforcer: environment.caveatEnforcers.ERC20PeriodTransferEnforcer,
+        args: '0x',
+        terms: concat([
+          config.tokenAddress,
+          toHex(config.periodAmount, { size: 32 }),
+          toHex(config.periodDuration, { size: 32 }),
+          toHex(config.startDate, { size: 32 }),
+        ]),
+      },
+    ]);
+  });
+
+  it('creates an ERC20 transfer amount CaveatBuilder', () => {
+    const config: Erc20UnitOfAuthorityConfig = {
+      environment,
+      tokenAddress: randomAddress(),
+      maxAmount: 1000n,
+    };
+
+    const caveatBuilder = createErc20CaveatBuilder(config);
+
+    const caveats = caveatBuilder.build();
+
+    expect(caveats).to.deep.equal([
+      {
+        enforcer: environment.caveatEnforcers.ValueLteEnforcer,
+        args: '0x',
+        terms:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+      },
+      {
+        enforcer: environment.caveatEnforcers.ERC20TransferAmountEnforcer,
+        args: '0x',
+        terms: concat([
+          config.tokenAddress,
+          toHex(config.maxAmount, { size: 32 }),
+        ]),
+      },
+    ]);
+  });
+
+  it('creates a specific action ERC20 transfer batch CaveatBuilder', () => {
+    const config: Erc20UnitOfAuthorityConfig = {
+      environment,
+      tokenAddress: randomAddress(),
+      recipient: randomAddress(),
+      amount: 1000n,
+      firstTarget: randomAddress(),
+      firstCalldata: '0x',
+    };
+
+    const caveatBuilder = createErc20CaveatBuilder(config);
+
+    const caveats = caveatBuilder.build();
+
+    expect(caveats).to.deep.equal([
+      {
+        enforcer: environment.caveatEnforcers.ValueLteEnforcer,
+        args: '0x',
+        terms:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+      },
+      {
+        enforcer:
+          environment.caveatEnforcers.SpecificActionERC20TransferBatchEnforcer,
+        args: '0x',
+        terms: concat([
+          config.tokenAddress,
+          config.recipient,
+          toHex(config.amount, { size: 32 }),
+          config.firstTarget,
+          config.firstCalldata,
+        ]),
+      },
+    ]);
+  });
+
+  it('throws an error for invalid configuration', () => {
+    const config = { environment } as any;
+
+    expect(() => createErc20CaveatBuilder(config)).to.throw(
+      'Invalid ERC20 configuration',
+    );
+  });
+});

--- a/packages/delegation-toolkit/test/caveatBuilder/erc721BalanceChangeBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/erc721BalanceChangeBuilder.test.ts
@@ -15,16 +15,11 @@ describe('erc721BalanceChangeBuilder()', () => {
   const buildWithParams = (
     tokenAddress: Address,
     recipient: Address,
-    balance: bigint,
+    amount: bigint,
     changeType: BalanceChangeType,
   ) => {
-    return erc721BalanceChangeBuilder(
-      environment,
-      tokenAddress,
-      recipient,
-      balance,
-      changeType,
-    );
+    const config = { tokenAddress, recipient, amount, changeType };
+    return erc721BalanceChangeBuilder(environment, config);
   };
 
   describe('validation', () => {

--- a/packages/delegation-toolkit/test/caveatBuilder/erc721TransferBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/erc721TransferBuilder.test.ts
@@ -17,11 +17,8 @@ describe('erc721TransferBuilder()', () => {
     permittedContract: Address,
     permittedTokenId: bigint,
   ) => {
-    return erc721TransferBuilder(
-      environment,
-      permittedContract,
-      permittedTokenId,
-    );
+    const config = { permittedContract, permittedTokenId };
+    return erc721TransferBuilder(environment, config);
   };
 
   describe('validation', () => {

--- a/packages/delegation-toolkit/test/caveatBuilder/erc721UnitOfAuthority.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/erc721UnitOfAuthority.test.ts
@@ -1,0 +1,45 @@
+import { expect } from 'chai';
+import { createErc721CaveatBuilder } from '../../src/caveatBuilder/erc721UnitOfAuthority';
+import type { Erc721UnitOfAuthorityConfig } from '../../src/caveatBuilder/erc721UnitOfAuthority';
+import { DeleGatorEnvironment } from 'src';
+import { randomAddress } from '../utils';
+import { concat, toHex } from 'viem';
+
+describe('createErc721CaveatBuilder', () => {
+  const environment = {
+    caveatEnforcers: {
+      ERC721TransferEnforcer: randomAddress(),
+    },
+  } as unknown as DeleGatorEnvironment;
+
+  it('creates an ERC721 transfer CaveatBuilder', () => {
+    const config: Erc721UnitOfAuthorityConfig = {
+      environment,
+      permittedContract: randomAddress(),
+      permittedTokenId: 1n,
+    };
+
+    const caveatBuilder = createErc721CaveatBuilder(config);
+
+    const caveats = caveatBuilder.build();
+
+    expect(caveats).to.deep.equal([
+      {
+        enforcer: environment.caveatEnforcers.ERC721TransferEnforcer,
+        args: '0x',
+        terms: concat([
+          config.permittedContract,
+          toHex(config.permittedTokenId, { size: 32 }),
+        ]),
+      },
+    ]);
+  });
+
+  it('throws an error for invalid configuration', () => {
+    const config = { environment } as any;
+
+    expect(() => createErc721CaveatBuilder(config)).to.throw(
+      'Invalid ERC721 configuration',
+    );
+  });
+});

--- a/packages/delegation-toolkit/test/caveatBuilder/erc721UnitOfAuthority.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/erc721UnitOfAuthority.test.ts
@@ -1,9 +1,10 @@
 import { expect } from 'chai';
+import { concat, toHex } from 'viem';
+
 import { createErc721CaveatBuilder } from '../../src/caveatBuilder/erc721UnitOfAuthority';
 import type { Erc721UnitOfAuthorityConfig } from '../../src/caveatBuilder/erc721UnitOfAuthority';
-import { DeleGatorEnvironment } from 'src';
 import { randomAddress } from '../utils';
-import { concat, toHex } from 'viem';
+import type { DeleGatorEnvironment } from 'src';
 
 describe('createErc721CaveatBuilder', () => {
   const environment = {

--- a/packages/delegation-toolkit/test/caveatBuilder/exactCalldataBatchBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/exactCalldataBatchBuilder.test.ts
@@ -18,7 +18,8 @@ describe('exactCalldataBatchBuilder()', () => {
       callData: `0x${string}`;
     }[],
   ) => {
-    return exactCalldataBatchBuilder(environment, executions);
+    const config = { executions };
+    return exactCalldataBatchBuilder(environment, config);
   };
 
   describe('validation', () => {
@@ -62,7 +63,7 @@ describe('exactCalldataBatchBuilder()', () => {
             callData: 'invalid' as `0x${string}`,
           },
         ]),
-      ).to.throw('Invalid callData: must be a hex string starting with 0x');
+      ).to.throw('Invalid calldata: must be a hex string starting with 0x');
     });
 
     it('should allow valid addresses that are not checksummed', () => {

--- a/packages/delegation-toolkit/test/caveatBuilder/exactCalldataBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/exactCalldataBuilder.test.ts
@@ -9,29 +9,30 @@ describe('exactCalldataBuilder()', () => {
     caveatEnforcers: { ExactCalldataEnforcer: randomAddress() },
   } as any as DeleGatorEnvironment;
 
-  const buildWithParams = (callData: `0x${string}`) => {
-    return exactCalldataBuilder(environment, callData);
+  const buildWithParams = (calldata: `0x${string}`) => {
+    const config = { calldata };
+    return exactCalldataBuilder(environment, config);
   };
 
   describe('validation', () => {
-    it('should fail with invalid callData format', () => {
+    it('should fail with invalid calldata format', () => {
       expect(() => buildWithParams('invalid' as `0x${string}`)).to.throw(
-        'Invalid callData: must be a hex string starting with 0x',
+        'Invalid calldata: must be a hex string starting with 0x',
       );
     });
   });
 
   describe('builds a caveat', () => {
     it('should build a caveat with valid parameters', () => {
-      const callData = '0x1234567890abcdef' as const;
+      const calldata = '0x1234567890abcdef' as const;
 
-      const caveat = buildWithParams(callData);
+      const caveat = buildWithParams(calldata);
 
       expect(caveat.enforcer).to.equal(
         environment.caveatEnforcers.ExactCalldataEnforcer,
       );
       expect(caveat.args).to.equal('0x');
-      expect(caveat.terms).to.equal(callData);
+      expect(caveat.terms).to.equal(calldata);
     });
   });
 });

--- a/packages/delegation-toolkit/test/caveatBuilder/exactExecutionBatchBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/exactExecutionBatchBuilder.test.ts
@@ -18,7 +18,8 @@ describe('exactExecutionBatchBuilder()', () => {
       callData: `0x${string}`;
     }[],
   ) => {
-    return exactExecutionBatchBuilder(environment, executions);
+    const config = { executions };
+    return exactExecutionBatchBuilder(environment, config);
   };
 
   describe('validation', () => {
@@ -62,7 +63,7 @@ describe('exactExecutionBatchBuilder()', () => {
             callData: 'invalid' as `0x${string}`,
           },
         ]),
-      ).to.throw('Invalid callData: must be a hex string starting with 0x');
+      ).to.throw('Invalid calldata: must be a hex string starting with 0x');
     });
 
     it('should allow valid addresses that are not checksummed', () => {

--- a/packages/delegation-toolkit/test/caveatBuilder/exactExecutionBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/exactExecutionBuilder.test.ts
@@ -16,50 +16,63 @@ describe('exactExecutionBuilder()', () => {
     value: bigint;
     callData: `0x${string}`;
   }) => {
-    return exactExecutionBuilder(environment, execution);
+    const config = { execution };
+    return exactExecutionBuilder(environment, config);
   };
 
   describe('validation', () => {
     it('should fail with an invalid target address', () => {
       const invalidAddress = 'invalid-address' as Address;
-      expect(() =>
-        buildWithParams({
-          target: invalidAddress,
-          value: 0n,
-          callData: '0x',
-        }),
-      ).to.throw('Invalid target: must be a valid address');
+      expect(() => {
+        const config = {
+          execution: {
+            target: invalidAddress,
+            value: 0n,
+            callData: '0x' as `0x${string}`,
+          },
+        };
+        buildWithParams(config.execution);
+      }).to.throw('Invalid target: must be a valid address');
     });
 
     it('should fail with a negative value', () => {
-      expect(() =>
-        buildWithParams({
-          target: randomAddress(),
-          value: -1n,
-          callData: '0x',
-        }),
-      ).to.throw('Invalid value: must be a non-negative number');
+      expect(() => {
+        const config = {
+          execution: {
+            target: randomAddress(),
+            value: -1n,
+            callData: '0x' as `0x${string}`,
+          },
+        };
+        buildWithParams(config.execution);
+      }).to.throw('Invalid value: must be a non-negative number');
     });
 
     it('should fail with invalid callData format', () => {
-      expect(() =>
-        buildWithParams({
-          target: randomAddress(),
-          value: 0n,
-          callData: 'invalid' as `0x${string}`,
-        }),
-      ).to.throw('Invalid callData: must be a hex string starting with 0x');
+      expect(() => {
+        const config = {
+          execution: {
+            target: randomAddress(),
+            value: 0n,
+            callData: 'invalid' as `0x${string}`,
+          },
+        };
+        buildWithParams(config.execution);
+      }).to.throw('Invalid calldata: must be a hex string starting with 0x');
     });
 
     it('should allow valid addresses that are not checksummed', () => {
       const nonChecksummedAddress = randomAddress().toLowerCase() as Address;
-      expect(() =>
-        buildWithParams({
-          target: nonChecksummedAddress,
-          value: 0n,
-          callData: '0x',
-        }),
-      ).to.not.throw();
+      expect(() => {
+        const config = {
+          execution: {
+            target: nonChecksummedAddress,
+            value: 0n,
+            callData: '0x' as `0x${string}`,
+          },
+        };
+        buildWithParams(config.execution);
+      }).to.not.throw();
     });
   });
 
@@ -68,10 +81,10 @@ describe('exactExecutionBuilder()', () => {
       const execution = {
         target: randomAddress(),
         value: 1000000000000000000n, // 1 ETH
-        callData: '0x12345678' as const,
+        callData: '0x12345678' as `0x${string}`,
       };
-
-      const caveat = buildWithParams(execution);
+      const config = { execution };
+      const caveat = buildWithParams(config.execution);
 
       expect(caveat.enforcer).to.equal(
         environment.caveatEnforcers.ExactExecutionEnforcer,

--- a/packages/delegation-toolkit/test/caveatBuilder/functionCallUnitOfAuthority.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/functionCallUnitOfAuthority.test.ts
@@ -1,0 +1,117 @@
+import { expect } from 'chai';
+import { createFunctionCallCaveatBuilder } from '../../src/caveatBuilder/functionCallUnitOfAuthority';
+import type { FunctionCallUnitOfAuthorityConfig } from '../../src/caveatBuilder/functionCallUnitOfAuthority';
+import { randomAddress } from '../utils';
+import { DeleGatorEnvironment } from 'src';
+import { concat, Hex, toHex } from 'viem';
+
+describe('createFunctionCallCaveatBuilder', () => {
+  const environment = {
+    caveatEnforcers: {
+      AllowedTargetsEnforcer: randomAddress(),
+      AllowedMethodsEnforcer: randomAddress(),
+      AllowedCalldataEnforcer: randomAddress(),
+      ExactCalldataEnforcer: randomAddress(),
+    },
+  } as unknown as DeleGatorEnvironment;
+
+  it('creates a Function Call CaveatBuilder', () => {
+    const config: FunctionCallUnitOfAuthorityConfig = {
+      environment,
+      targets: [randomAddress()],
+      selectors: ['0x12345678'],
+    };
+
+    const caveatBuilder = createFunctionCallCaveatBuilder(config);
+
+    const caveats = caveatBuilder.build();
+
+    expect(caveats).to.deep.equal([
+      {
+        enforcer: environment.caveatEnforcers.AllowedTargetsEnforcer,
+        args: '0x',
+        terms: concat(config.targets),
+      },
+      {
+        enforcer: environment.caveatEnforcers.AllowedMethodsEnforcer,
+        args: '0x',
+        terms: concat(config.selectors as Hex[]),
+      },
+    ]);
+  });
+
+  it('creates a Function Call CaveatBuilder with allowed calldata', () => {
+    const allowedCalldata = { value: '0x12345678', startIndex: 0 } as const;
+    const config: FunctionCallUnitOfAuthorityConfig = {
+      environment,
+      targets: [randomAddress()],
+      selectors: ['0x12345678'],
+      allowedCalldata: [allowedCalldata],
+    };
+
+    const caveatBuilder = createFunctionCallCaveatBuilder(config);
+
+    const caveats = caveatBuilder.build();
+
+    expect(caveats).to.deep.equal([
+      {
+        enforcer: environment.caveatEnforcers.AllowedTargetsEnforcer,
+        args: '0x',
+        terms: concat(config.targets),
+      },
+      {
+        enforcer: environment.caveatEnforcers.AllowedMethodsEnforcer,
+        args: '0x',
+        terms: concat(config.selectors as Hex[]),
+      },
+      {
+        enforcer: environment.caveatEnforcers.AllowedCalldataEnforcer,
+        args: '0x',
+        terms: concat([
+          toHex(allowedCalldata.startIndex, { size: 32 }),
+          allowedCalldata.value,
+        ]),
+      },
+    ]);
+  });
+
+  it('creates a Function Call CaveatBuilder with exact calldata', () => {
+    const exactCalldata = { calldata: '0x12345678' } as const;
+    const config: FunctionCallUnitOfAuthorityConfig = {
+      environment,
+      targets: [randomAddress()],
+      selectors: ['0x12345678'],
+      exactCalldata,
+    };
+
+    const caveatBuilder = createFunctionCallCaveatBuilder(config);
+
+    const caveats = caveatBuilder.build();
+
+    expect(caveats).to.deep.equal([
+      {
+        enforcer: environment.caveatEnforcers.AllowedTargetsEnforcer,
+        args: '0x',
+        terms: concat(config.targets),
+      },
+      {
+        enforcer: environment.caveatEnforcers.AllowedMethodsEnforcer,
+        args: '0x',
+        terms: concat(config.selectors as Hex[]),
+      },
+      {
+        enforcer: environment.caveatEnforcers.ExactCalldataEnforcer,
+        args: '0x',
+        terms: exactCalldata.calldata,
+      },
+    ]);
+  });
+
+  it('throws an error for invalid configuration', () => {
+    const config = { environment } as any;
+
+    expect(() => createFunctionCallCaveatBuilder(config)).to.throw(
+      'Invalid Function Call configuration',
+    );
+  });
+});

--- a/packages/delegation-toolkit/test/caveatBuilder/functionCallUnitOfAuthority.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/functionCallUnitOfAuthority.test.ts
@@ -1,9 +1,11 @@
 import { expect } from 'chai';
+import type { Hex } from 'viem';
+import { concat, toHex } from 'viem';
+
 import { createFunctionCallCaveatBuilder } from '../../src/caveatBuilder/functionCallUnitOfAuthority';
 import type { FunctionCallUnitOfAuthorityConfig } from '../../src/caveatBuilder/functionCallUnitOfAuthority';
 import { randomAddress } from '../utils';
-import { DeleGatorEnvironment } from 'src';
-import { concat, Hex, toHex } from 'viem';
+import type { DeleGatorEnvironment } from 'src';
 
 describe('createFunctionCallCaveatBuilder', () => {
   const environment = {

--- a/packages/delegation-toolkit/test/caveatBuilder/idBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/idBuilder.test.ts
@@ -11,8 +11,9 @@ describe('idBuilder()', () => {
     caveatEnforcers: { IdEnforcer: randomAddress() },
   } as any as DeleGatorEnvironment;
 
-  const buildWithId = (id: bigint | number) => {
-    return idBuilder(environment, id);
+  const buildWithId = (idValue: bigint | number) => {
+    const config = { idValue };
+    return idBuilder(environment, config);
   };
 
   describe('validation', () => {
@@ -26,7 +27,7 @@ describe('idBuilder()', () => {
     it('should fail with an invalid id (negative)', () => {
       const invalidId = -1n;
       expect(() => buildWithId(invalidId)).to.throw(
-        'Invalid id: must be positive',
+        'Invalid id: must be a non-negative number',
       );
     });
 

--- a/packages/delegation-toolkit/test/caveatBuilder/limitedCallsBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/limitedCallsBuilder.test.ts
@@ -12,7 +12,8 @@ describe('limitedCallsBuilder()', () => {
   } as any as DeleGatorEnvironment;
 
   const buildWithLimit = (limit: number) => {
-    return limitedCallsBuilder(environment, limit);
+    const config = { limit };
+    return limitedCallsBuilder(environment, config);
   };
 
   describe('validation', () => {

--- a/packages/delegation-toolkit/test/caveatBuilder/nativeBalanceChangeBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/nativeBalanceChangeBuilder.test.ts
@@ -18,12 +18,8 @@ describe('nativeBalanceChangeBuilder', () => {
     balance: bigint,
     changeType: BalanceChangeType,
   ) => {
-    return nativeBalanceChangeBuilder(
-      environment,
-      recipient,
-      balance,
-      changeType,
-    );
+    const config = { recipient, balance, changeType };
+    return nativeBalanceChangeBuilder(environment, config);
   };
 
   describe('validation', () => {

--- a/packages/delegation-toolkit/test/caveatBuilder/nativeTokenPaymentBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/nativeTokenPaymentBuilder.test.ts
@@ -13,7 +13,8 @@ describe('nativeTokenPaymentBuilder()', () => {
   } as any as DeleGatorEnvironment;
 
   const buildWithAmountAndRecipient = (recipient: Hex, amount: bigint) => {
-    return nativeTokenPaymentBuilder(environment, recipient, amount);
+    const config = { recipient, amount };
+    return nativeTokenPaymentBuilder(environment, config);
   };
 
   describe('validation', () => {

--- a/packages/delegation-toolkit/test/caveatBuilder/nativeTokenPaymentBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/nativeTokenPaymentBuilder.test.ts
@@ -36,7 +36,7 @@ describe('nativeTokenPaymentBuilder()', () => {
   describe('builds a caveat', () => {
     it('should build a caveat with valid amount and recipient', () => {
       const amount = 1000000000000000000n; // 1 ETH
-      const recipient = randomAddress(true); // lowerCase because abi encoding lowercases addresses
+      const recipient = randomAddress('lowercase'); // lowerCase because abi encoding lowercases addresses
       const caveat = buildWithAmountAndRecipient(recipient, amount);
 
       const amountHex = toHex(amount, { size: 32 });
@@ -51,7 +51,7 @@ describe('nativeTokenPaymentBuilder()', () => {
 
     it('should build a caveat with minimum possible amount', () => {
       const amount = 1n;
-      const recipient = randomAddress(true); // lowerCase because abi encoding lowercases addressesç
+      const recipient = randomAddress('lowercase'); // lowerCase because abi encoding lowercases addressesç
 
       const caveat = buildWithAmountAndRecipient(recipient, amount);
 
@@ -68,7 +68,7 @@ describe('nativeTokenPaymentBuilder()', () => {
 
   it('should create a caveat with terms length matching number of targets', () => {
     const amount = 1000000000000000000n; // 1 ETH
-    const recipient = randomAddress(true); // lowerCase because abi encoding lowercases addresses
+    const recipient = randomAddress('lowercase'); // lowerCase because abi encoding lowercases addresses
 
     const caveat = buildWithAmountAndRecipient(recipient, amount);
 

--- a/packages/delegation-toolkit/test/caveatBuilder/nativeTokenPeriodTransferBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/nativeTokenPeriodTransferBuilder.test.ts
@@ -16,12 +16,8 @@ describe('nativeTokenPeriodTransferBuilder()', () => {
     periodDuration: number,
     startDate: number,
   ) => {
-    return nativeTokenPeriodTransferBuilder(
-      environment,
-      periodAmount,
-      periodDuration,
-      startDate,
-    );
+    const config = { periodAmount, periodDuration, startDate };
+    return nativeTokenPeriodTransferBuilder(environment, config);
   };
 
   describe('validation', () => {

--- a/packages/delegation-toolkit/test/caveatBuilder/nativeTokenStreamingBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/nativeTokenStreamingBuilder.test.ts
@@ -21,13 +21,8 @@ describe('nativeTokenStreamingBuilder()', () => {
     amountPerSecond: bigint,
     startTime: number,
   ) => {
-    return nativeTokenStreamingBuilder(
-      environment,
-      initialAmount,
-      maxAmount,
-      amountPerSecond,
-      startTime,
-    );
+    const config = { initialAmount, maxAmount, amountPerSecond, startTime };
+    return nativeTokenStreamingBuilder(environment, config);
   };
 
   describe('validation', () => {

--- a/packages/delegation-toolkit/test/caveatBuilder/nativeTokenTransferAmountBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/nativeTokenTransferAmountBuilder.test.ts
@@ -12,14 +12,15 @@ describe('nativeTokenTransferAmountBuilder()', () => {
     caveatEnforcers: { NativeTokenTransferAmountEnforcer: randomAddress() },
   } as any as DeleGatorEnvironment;
 
-  const buildWithAllowance = (allowance: bigint) => {
-    return nativeTokenTransferAmountBuilder(environment, allowance);
+  const buildWithAllowance = (maxAmount: bigint) => {
+    const config = { maxAmount };
+    return nativeTokenTransferAmountBuilder(environment, config);
   };
 
   describe('validation', () => {
     it('should fail with negative allowance', () => {
       expect(() => buildWithAllowance(-1n)).to.throw(
-        'Invalid allowance: must be zero or positive',
+        'Invalid maxAmount: must be zero or positive',
       );
     });
   });

--- a/packages/delegation-toolkit/test/caveatBuilder/nativeTokenUnitOfAuthority.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/nativeTokenUnitOfAuthority.test.ts
@@ -1,9 +1,10 @@
 import { expect } from 'chai';
+import { concat, toHex } from 'viem';
+
 import { createNativeTokenCaveatBuilder } from '../../src/caveatBuilder/nativeTokenUnitOfAuthority';
 import type { NativeTokenUnitOfAuthorityConfig } from '../../src/caveatBuilder/nativeTokenUnitOfAuthority';
-import { DeleGatorEnvironment } from 'src';
 import { randomAddress } from '../utils';
-import { concat, toHex } from 'viem';
+import type { DeleGatorEnvironment } from 'src';
 
 describe('createNativeTokenCaveatBuilder', () => {
   const environment = {

--- a/packages/delegation-toolkit/test/caveatBuilder/nativeTokenUnitOfAuthority.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/nativeTokenUnitOfAuthority.test.ts
@@ -1,0 +1,111 @@
+import { expect } from 'chai';
+import { createNativeTokenCaveatBuilder } from '../../src/caveatBuilder/nativeTokenUnitOfAuthority';
+import type { NativeTokenUnitOfAuthorityConfig } from '../../src/caveatBuilder/nativeTokenUnitOfAuthority';
+import { DeleGatorEnvironment } from 'src';
+import { randomAddress } from '../utils';
+import { concat, toHex } from 'viem';
+
+describe('createNativeTokenCaveatBuilder', () => {
+  const environment = {
+    caveatEnforcers: {
+      NativeTokenStreamingEnforcer: randomAddress(),
+      NativeTokenPeriodTransferEnforcer: randomAddress(),
+      NativeTokenTransferAmountEnforcer: randomAddress(),
+      ExactCalldataEnforcer: randomAddress(),
+    },
+  } as unknown as DeleGatorEnvironment;
+
+  it('creates a Native Token Streaming CaveatBuilder', () => {
+    const config: NativeTokenUnitOfAuthorityConfig = {
+      environment,
+      initialAmount: 1000n,
+      maxAmount: 10000n,
+      amountPerSecond: 1n,
+      startTime: Math.floor(Date.now() / 1000),
+    };
+
+    const caveatBuilder = createNativeTokenCaveatBuilder(config);
+
+    const caveats = caveatBuilder.build();
+
+    expect(caveats).to.deep.equal([
+      {
+        enforcer: environment.caveatEnforcers.ExactCalldataEnforcer,
+        args: '0x',
+        terms: '0x',
+      },
+      {
+        enforcer: environment.caveatEnforcers.NativeTokenStreamingEnforcer,
+        args: '0x',
+        terms: concat([
+          toHex(config.initialAmount, { size: 32 }),
+          toHex(config.maxAmount, { size: 32 }),
+          toHex(config.amountPerSecond, { size: 32 }),
+          toHex(config.startTime, { size: 32 }),
+        ]),
+      },
+    ]);
+  });
+
+  it('creates a Native Token Period Transfer CaveatBuilder', () => {
+    const config: NativeTokenUnitOfAuthorityConfig = {
+      environment,
+      periodAmount: 1000n,
+      periodDuration: 1000,
+      startDate: Math.floor(Date.now() / 1000),
+    };
+
+    const caveatBuilder = createNativeTokenCaveatBuilder(config);
+
+    const caveats = caveatBuilder.build();
+
+    expect(caveats).to.deep.equal([
+      {
+        enforcer: environment.caveatEnforcers.ExactCalldataEnforcer,
+        args: '0x',
+        terms: '0x',
+      },
+      {
+        enforcer: environment.caveatEnforcers.NativeTokenPeriodTransferEnforcer,
+        args: '0x',
+        terms: concat([
+          toHex(config.periodAmount, { size: 32 }),
+          toHex(config.periodDuration, { size: 32 }),
+          toHex(config.startDate, { size: 32 }),
+        ]),
+      },
+    ]);
+  });
+
+  it('creates a Native Token Transfer Amount CaveatBuilder', () => {
+    const config: NativeTokenUnitOfAuthorityConfig = {
+      environment,
+      maxAmount: 10000n,
+    };
+
+    const caveatBuilder = createNativeTokenCaveatBuilder(config);
+
+    const caveats = caveatBuilder.build();
+
+    expect(caveats).to.deep.equal([
+      {
+        enforcer: environment.caveatEnforcers.ExactCalldataEnforcer,
+        args: '0x',
+        terms: '0x',
+      },
+      {
+        enforcer: environment.caveatEnforcers.NativeTokenTransferAmountEnforcer,
+        args: '0x',
+        terms: toHex(config.maxAmount, { size: 32 }),
+      },
+    ]);
+  });
+
+  it('throws an error for invalid configuration', () => {
+    const config = { environment } as any;
+
+    expect(() => createNativeTokenCaveatBuilder(config)).to.throw(
+      'Invalid native token configuration',
+    );
+  });
+});

--- a/packages/delegation-toolkit/test/caveatBuilder/nonceBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/nonceBuilder.test.ts
@@ -12,8 +12,9 @@ describe('nonceBuilder()', () => {
     caveatEnforcers: { NonceEnforcer: randomAddress() },
   } as any as DeleGatorEnvironment;
 
-  const buildWithNonce = (nonce: Hex) => {
-    return nonceBuilder(environment, nonce);
+  const buildWithNonce = (nonceValue: Hex) => {
+    const config = { nonceValue };
+    return nonceBuilder(environment, config);
   };
 
   describe('validation', () => {

--- a/packages/delegation-toolkit/test/caveatBuilder/ownershipTransferBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/ownershipTransferBuilder.test.ts
@@ -13,7 +13,8 @@ describe('ownershipTransferBuilder()', () => {
   } as any as DeleGatorEnvironment;
 
   const buildWithParams = (targetContract: Address) => {
-    return ownershipTransferBuilder(environment, targetContract);
+    const config = { targetContract };
+    return ownershipTransferBuilder(environment, config);
   };
 
   describe('builds a caveat', () => {

--- a/packages/delegation-toolkit/test/caveatBuilder/ownershipUnitOfAuthority.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/ownershipUnitOfAuthority.test.ts
@@ -1,0 +1,42 @@
+import { expect } from 'chai';
+import { createOwnershipTransferCaveatBuilder } from '../../src/caveatBuilder/ownershipUnitOfAuthority';
+import type { OwnershipUnitOfAuthorityConfig } from '../../src/caveatBuilder/ownershipUnitOfAuthority';
+import { randomAddress } from '../utils';
+import { DeleGatorEnvironment } from 'src';
+
+describe('createOwnershipTransferCaveatBuilder', () => {
+  const environment = {
+    caveatEnforcers: {
+      OwnershipTransferEnforcer: randomAddress(),
+    },
+  } as unknown as DeleGatorEnvironment;
+
+  it('creates an Ownership Transfer CaveatBuilder', () => {
+    const config: OwnershipUnitOfAuthorityConfig = {
+      targetContract: randomAddress(),
+    };
+
+    const caveatBuilder = createOwnershipTransferCaveatBuilder(
+      environment,
+      config,
+    );
+
+    const caveats = caveatBuilder.build();
+
+    expect(caveats).to.deep.equal([
+      {
+        enforcer: environment.caveatEnforcers.OwnershipTransferEnforcer,
+        args: '0x',
+        terms: config.targetContract,
+      },
+    ]);
+  });
+
+  it('throws an error for invalid configuration', () => {
+    const config: any = {};
+
+    expect(() =>
+      createOwnershipTransferCaveatBuilder(environment, config),
+    ).to.throw('Invalid ownership transfer configuration');
+  });
+});

--- a/packages/delegation-toolkit/test/caveatBuilder/ownershipUnitOfAuthority.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/ownershipUnitOfAuthority.test.ts
@@ -1,8 +1,9 @@
 import { expect } from 'chai';
+
 import { createOwnershipTransferCaveatBuilder } from '../../src/caveatBuilder/ownershipUnitOfAuthority';
 import type { OwnershipUnitOfAuthorityConfig } from '../../src/caveatBuilder/ownershipUnitOfAuthority';
 import { randomAddress } from '../utils';
-import { DeleGatorEnvironment } from 'src';
+import type { DeleGatorEnvironment } from 'src';
 
 describe('createOwnershipTransferCaveatBuilder', () => {
   const environment = {

--- a/packages/delegation-toolkit/test/caveatBuilder/redeemerBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/redeemerBuilder.test.ts
@@ -17,7 +17,8 @@ describe('redeemerBuilder()', () => {
   });
 
   const buildWithRedeemerAddresses = (redeemers: Address[]) => {
-    return redeemerBuilder(environment, redeemers);
+    const config = { redeemers };
+    return redeemerBuilder(environment, config);
   };
 
   describe('validation', () => {

--- a/packages/delegation-toolkit/test/caveatBuilder/resolveCaveats.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/resolveCaveats.test.ts
@@ -1,0 +1,244 @@
+import { expect } from 'chai';
+
+import { resolveCaveats } from '../../src/caveatBuilder/resolveCaveats';
+import { CaveatBuilder } from '../../src/caveatBuilder/caveatBuilder';
+import {
+  CoreCaveatConfiguration,
+  createCaveatBuilder,
+} from '../../src/caveatBuilder/coreCaveatBuilder';
+import type { Caveat, DeleGatorEnvironment } from '../../src/types';
+import type { ScopeConfig } from '../../src/caveatBuilder/scope';
+import { randomAddress } from '../utils';
+
+describe('resolveCaveats', () => {
+  const environment: DeleGatorEnvironment = {
+    caveatEnforcers: {
+      AllowedMethodsEnforcer: randomAddress(),
+      BlockNumberEnforcer: randomAddress(),
+      ValueLteEnforcer: randomAddress(),
+      ERC721TransferEnforcer: randomAddress(),
+      ERC20TransferAmountEnforcer: randomAddress(),
+    },
+  } as unknown as DeleGatorEnvironment;
+
+  const mockCaveat1: Caveat = {
+    enforcer: randomAddress(),
+    terms: '0x01' as const,
+    args: '0x',
+  };
+
+  const mockCaveat2: Caveat = {
+    enforcer: randomAddress(),
+    terms: '0x02' as const,
+    args: '0x',
+  };
+
+  const erc20Scope: ScopeConfig = {
+    type: 'erc20',
+    tokenAddress: randomAddress(),
+    maxAmount: 1000n,
+  };
+
+  describe('when caveats is a CaveatBuilder', () => {
+    it('should resolve caveats from a CaveatBuilder instance', () => {
+      const caveatBuilder = new CaveatBuilder(environment);
+      caveatBuilder.addCaveat(mockCaveat1);
+      caveatBuilder.addCaveat(mockCaveat2);
+
+      const result = resolveCaveats({
+        environment,
+        scope: erc20Scope,
+        caveats: caveatBuilder,
+      });
+
+      // 4 caveats: 2 from the scope, 2 from the builder
+      expect(result).to.have.lengthOf(4);
+      expect(result).to.deep.include(mockCaveat1);
+      expect(result).to.deep.include(mockCaveat2);
+    });
+
+    it('should handle empty CaveatBuilder', () => {
+      const caveatBuilder = new CaveatBuilder(environment, {
+        allowInsecureUnrestrictedDelegation: true,
+      });
+
+      const result = resolveCaveats({
+        environment,
+        scope: erc20Scope,
+        caveats: caveatBuilder,
+      });
+
+      expect(result).to.be.an('array');
+      expect(result.length).to.be.greaterThan(0); // Should have scope caveats
+    });
+
+    it('should handle CoreCaveatBuilder with named caveats', () => {
+      const caveatBuilder = createCaveatBuilder(environment, {
+        allowInsecureUnrestrictedDelegation: true,
+      });
+      caveatBuilder.addCaveat('allowedMethods', {
+        selectors: ['0x12345678'],
+      });
+
+      const result = resolveCaveats({
+        environment,
+        scope: erc20Scope,
+        caveats: caveatBuilder as any,
+      });
+
+      expect(result).to.be.an('array');
+      expect(result.length).to.be.greaterThan(1); // Should have scope caveats + our added caveat
+    });
+  });
+
+  describe('when caveats is an array', () => {
+    it('should resolve caveats from an array of Caveat objects', () => {
+      const caveats = [mockCaveat1, mockCaveat2];
+
+      const result = resolveCaveats({
+        environment,
+        scope: erc20Scope,
+        caveats,
+      });
+
+      expect(result).to.be.an('array');
+      expect(result.length).to.be.greaterThan(2); // Should have scope caveats + our added caveats
+
+      // Check that our caveats are included
+      expect(result).to.deep.include(mockCaveat1);
+      expect(result).to.deep.include(mockCaveat2);
+    });
+
+    it('should resolve caveats from an array of CaveatConfiguration objects', () => {
+      const caveatConfigs: CoreCaveatConfiguration[] = [
+        {
+          type: 'allowedMethods',
+          selectors: ['0x12345678'],
+        },
+        {
+          type: 'blockNumber',
+          blockAfterThreshold: 0n,
+          blockBeforeThreshold: 1000n,
+        },
+      ];
+
+      const result = resolveCaveats({
+        environment,
+        scope: erc20Scope,
+        caveats: caveatConfigs,
+      });
+
+      expect(result).to.be.an('array');
+      expect(result.length).to.be.greaterThan(2); // Should have scope caveats + our added caveats
+
+      // Verify that the caveats were added by checking the result contains more than just scope caveats
+      const scopeOnlyResult = resolveCaveats({
+        environment,
+        scope: erc20Scope,
+        caveats: [],
+      });
+      expect(result.length).to.be.greaterThan(scopeOnlyResult.length);
+    });
+
+    it('should resolve caveats from a mixed array of Caveat and CaveatConfiguration objects', () => {
+      const mixedCaveats = [
+        mockCaveat1,
+        {
+          type: 'allowedMethods',
+          selectors: ['0x12345678'],
+        } as CoreCaveatConfiguration,
+        mockCaveat2,
+        {
+          type: 'blockNumber',
+          blockAfterThreshold: 0n,
+          blockBeforeThreshold: 1000n,
+        } as CoreCaveatConfiguration,
+      ];
+
+      const result = resolveCaveats({
+        environment,
+        scope: erc20Scope,
+        caveats: mixedCaveats,
+      });
+
+      expect(result).to.be.an('array');
+      expect(result.length).to.be.greaterThan(4); // Should have scope caveats + our 4 added items
+
+      // Check that our direct caveats are included
+      expect(result).to.deep.include(mockCaveat1);
+      expect(result).to.deep.include(mockCaveat2);
+    });
+
+    it('should handle empty array', () => {
+      const result = resolveCaveats({
+        environment,
+        scope: erc20Scope,
+        caveats: [],
+      });
+
+      expect(result).to.be.an('array');
+      expect(result.length).to.be.greaterThan(0); // Should have scope caveats
+    });
+  });
+
+  describe('scope', () => {
+    it('should work with different scope types', () => {
+      const erc721Scope: ScopeConfig = {
+        type: 'erc721',
+        permittedContract: randomAddress(),
+        permittedTokenId: 123n,
+      };
+
+      const caveatConfig: CoreCaveatConfiguration = {
+        type: 'allowedMethods',
+        selectors: ['0x12345678'],
+      };
+
+      const result = resolveCaveats({
+        environment,
+        scope: erc721Scope,
+        caveats: [caveatConfig],
+      });
+
+      expect(result).to.be.an('array');
+      expect(result.length).to.be.greaterThan(0);
+    });
+
+    it('should include scope-specific caveats', () => {
+      const resultWithCaveats = resolveCaveats({
+        environment,
+        scope: erc20Scope,
+        caveats: [mockCaveat1],
+      });
+
+      const resultWithoutCaveats = resolveCaveats({
+        environment,
+        scope: erc20Scope,
+        caveats: [],
+      });
+
+      expect(resultWithCaveats.length).to.be.greaterThan(
+        resultWithoutCaveats.length,
+      );
+
+      expect(resultWithoutCaveats.length).to.be.greaterThan(0);
+    });
+  });
+
+  describe('error handling and edge cases', () => {
+    it('fails with malformed objects gracefully', () => {
+      const invalidType = {
+        type: 'nonExistentType',
+        someProperty: 'value',
+      };
+
+      expect(() => {
+        resolveCaveats({
+          environment,
+          scope: erc20Scope,
+          caveats: [invalidType as any],
+        });
+      }).to.throw('Invalid caveat');
+    });
+  });
+});

--- a/packages/delegation-toolkit/test/caveatBuilder/resolveCaveats.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/resolveCaveats.test.ts
@@ -1,13 +1,11 @@
 import { expect } from 'chai';
 
-import { resolveCaveats } from '../../src/caveatBuilder/resolveCaveats';
 import { CaveatBuilder } from '../../src/caveatBuilder/caveatBuilder';
-import {
-  CoreCaveatConfiguration,
-  createCaveatBuilder,
-} from '../../src/caveatBuilder/coreCaveatBuilder';
-import type { Caveat, DeleGatorEnvironment } from '../../src/types';
+import type { CoreCaveatConfiguration } from '../../src/caveatBuilder/coreCaveatBuilder';
+import { createCaveatBuilder } from '../../src/caveatBuilder/coreCaveatBuilder';
+import { resolveCaveats } from '../../src/caveatBuilder/resolveCaveats';
 import type { ScopeConfig } from '../../src/caveatBuilder/scope';
+import type { Caveat, DeleGatorEnvironment } from '../../src/types';
 import { randomAddress } from '../utils';
 
 describe('resolveCaveats', () => {

--- a/packages/delegation-toolkit/test/caveatBuilder/scope/erc20Scope.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/scope/erc20Scope.test.ts
@@ -1,10 +1,10 @@
 import { expect } from 'chai';
 import { concat, toHex } from 'viem';
 
-import { createErc20CaveatBuilder } from '../../src/caveatBuilder/erc20UnitOfAuthority';
-import type { Erc20UnitOfAuthorityConfig } from '../../src/caveatBuilder/erc20UnitOfAuthority';
-import { randomAddress } from '../utils';
-import type { DeleGatorEnvironment } from 'src';
+import { createErc20CaveatBuilder } from '../../../src/caveatBuilder/scope/erc20Scope';
+import type { Erc20ScopeConfig } from '../../../src/caveatBuilder/scope/erc20Scope';
+import type { DeleGatorEnvironment } from '../../../src/types';
+import { randomAddress } from '../../utils';
 
 describe('createErc20CaveatBuilder', () => {
   const environment = {
@@ -18,8 +18,8 @@ describe('createErc20CaveatBuilder', () => {
   } as unknown as DeleGatorEnvironment;
 
   it('creates an ERC20 streaming CaveatBuilder', () => {
-    const config: Erc20UnitOfAuthorityConfig = {
-      environment,
+    const config: Erc20ScopeConfig = {
+      type: 'erc20',
       tokenAddress: randomAddress(),
       initialAmount: 1000n,
       maxAmount: 10000n,
@@ -27,7 +27,7 @@ describe('createErc20CaveatBuilder', () => {
       startTime: Math.floor(Date.now() / 1000),
     };
 
-    const caveatBuilder = createErc20CaveatBuilder(config);
+    const caveatBuilder = createErc20CaveatBuilder(environment, config);
 
     const caveats = caveatBuilder.build();
 
@@ -53,15 +53,15 @@ describe('createErc20CaveatBuilder', () => {
   });
 
   it('creates an ERC20 period transfer CaveatBuilder', () => {
-    const config: Erc20UnitOfAuthorityConfig = {
-      environment,
+    const config: Erc20ScopeConfig = {
+      type: 'erc20',
       tokenAddress: randomAddress(),
       periodAmount: 1000n,
       periodDuration: 1000,
       startDate: Math.floor(Date.now() / 1000),
     };
 
-    const caveatBuilder = createErc20CaveatBuilder(config);
+    const caveatBuilder = createErc20CaveatBuilder(environment, config);
 
     const caveats = caveatBuilder.build();
 
@@ -86,13 +86,13 @@ describe('createErc20CaveatBuilder', () => {
   });
 
   it('creates an ERC20 transfer amount CaveatBuilder', () => {
-    const config: Erc20UnitOfAuthorityConfig = {
-      environment,
+    const config: Erc20ScopeConfig = {
+      type: 'erc20',
       tokenAddress: randomAddress(),
       maxAmount: 1000n,
     };
 
-    const caveatBuilder = createErc20CaveatBuilder(config);
+    const caveatBuilder = createErc20CaveatBuilder(environment, config);
 
     const caveats = caveatBuilder.build();
 
@@ -115,8 +115,8 @@ describe('createErc20CaveatBuilder', () => {
   });
 
   it('creates a specific action ERC20 transfer batch CaveatBuilder', () => {
-    const config: Erc20UnitOfAuthorityConfig = {
-      environment,
+    const config: Erc20ScopeConfig = {
+      type: 'erc20',
       tokenAddress: randomAddress(),
       recipient: randomAddress(),
       amount: 1000n,
@@ -124,7 +124,7 @@ describe('createErc20CaveatBuilder', () => {
       firstCalldata: '0x',
     };
 
-    const caveatBuilder = createErc20CaveatBuilder(config);
+    const caveatBuilder = createErc20CaveatBuilder(environment, config);
 
     const caveats = caveatBuilder.build();
 
@@ -151,9 +151,9 @@ describe('createErc20CaveatBuilder', () => {
   });
 
   it('throws an error for invalid configuration', () => {
-    const config = { environment } as any;
+    const config = { type: 'erc20' } as unknown as Erc20ScopeConfig;
 
-    expect(() => createErc20CaveatBuilder(config)).to.throw(
+    expect(() => createErc20CaveatBuilder(environment, config)).to.throw(
       'Invalid ERC20 configuration',
     );
   });

--- a/packages/delegation-toolkit/test/caveatBuilder/scope/erc721Scope.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/scope/erc721Scope.test.ts
@@ -1,10 +1,10 @@
 import { expect } from 'chai';
 import { concat, toHex } from 'viem';
 
-import { createErc721CaveatBuilder } from '../../src/caveatBuilder/erc721UnitOfAuthority';
-import type { Erc721UnitOfAuthorityConfig } from '../../src/caveatBuilder/erc721UnitOfAuthority';
-import { randomAddress } from '../utils';
-import type { DeleGatorEnvironment } from 'src';
+import { createErc721CaveatBuilder } from '../../../src/caveatBuilder/scope/erc721Scope';
+import type { Erc721ScopeConfig } from '../../../src/caveatBuilder/scope/erc721Scope';
+import type { DeleGatorEnvironment } from '../../../src/types';
+import { randomAddress } from '../../utils';
 
 describe('createErc721CaveatBuilder', () => {
   const environment = {
@@ -14,13 +14,13 @@ describe('createErc721CaveatBuilder', () => {
   } as unknown as DeleGatorEnvironment;
 
   it('creates an ERC721 transfer CaveatBuilder', () => {
-    const config: Erc721UnitOfAuthorityConfig = {
-      environment,
+    const config: Erc721ScopeConfig = {
+      type: 'erc721',
       permittedContract: randomAddress(),
       permittedTokenId: 1n,
     };
 
-    const caveatBuilder = createErc721CaveatBuilder(config);
+    const caveatBuilder = createErc721CaveatBuilder(environment, config);
 
     const caveats = caveatBuilder.build();
 
@@ -37,9 +37,9 @@ describe('createErc721CaveatBuilder', () => {
   });
 
   it('throws an error for invalid configuration', () => {
-    const config = { environment } as any;
+    const config = { type: 'erc721' } as unknown as Erc721ScopeConfig;
 
-    expect(() => createErc721CaveatBuilder(config)).to.throw(
+    expect(() => createErc721CaveatBuilder(environment, config)).to.throw(
       'Invalid ERC721 configuration',
     );
   });

--- a/packages/delegation-toolkit/test/caveatBuilder/scope/functionCallScope.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/scope/functionCallScope.test.ts
@@ -2,10 +2,10 @@ import { expect } from 'chai';
 import type { Hex } from 'viem';
 import { concat, toHex } from 'viem';
 
-import { createFunctionCallCaveatBuilder } from '../../src/caveatBuilder/functionCallUnitOfAuthority';
-import type { FunctionCallUnitOfAuthorityConfig } from '../../src/caveatBuilder/functionCallUnitOfAuthority';
-import { randomAddress } from '../utils';
-import type { DeleGatorEnvironment } from 'src';
+import { createFunctionCallCaveatBuilder } from '../../../src/caveatBuilder/scope/functionCallScope';
+import type { FunctionCallScopeConfig } from '../../../src/caveatBuilder/scope/functionCallScope';
+import type { DeleGatorEnvironment } from '../../../src/types';
+import { randomAddress } from '../../utils';
 
 describe('createFunctionCallCaveatBuilder', () => {
   const environment = {
@@ -18,13 +18,13 @@ describe('createFunctionCallCaveatBuilder', () => {
   } as unknown as DeleGatorEnvironment;
 
   it('creates a Function Call CaveatBuilder', () => {
-    const config: FunctionCallUnitOfAuthorityConfig = {
-      environment,
+    const config: FunctionCallScopeConfig = {
+      type: 'functionCall',
       targets: [randomAddress()],
       selectors: ['0x12345678'],
     };
 
-    const caveatBuilder = createFunctionCallCaveatBuilder(config);
+    const caveatBuilder = createFunctionCallCaveatBuilder(environment, config);
 
     const caveats = caveatBuilder.build();
 
@@ -44,14 +44,14 @@ describe('createFunctionCallCaveatBuilder', () => {
 
   it('creates a Function Call CaveatBuilder with allowed calldata', () => {
     const allowedCalldata = { value: '0x12345678', startIndex: 0 } as const;
-    const config: FunctionCallUnitOfAuthorityConfig = {
-      environment,
+    const config: FunctionCallScopeConfig = {
+      type: 'functionCall',
       targets: [randomAddress()],
       selectors: ['0x12345678'],
       allowedCalldata: [allowedCalldata],
     };
 
-    const caveatBuilder = createFunctionCallCaveatBuilder(config);
+    const caveatBuilder = createFunctionCallCaveatBuilder(environment, config);
 
     const caveats = caveatBuilder.build();
 
@@ -79,14 +79,14 @@ describe('createFunctionCallCaveatBuilder', () => {
 
   it('creates a Function Call CaveatBuilder with exact calldata', () => {
     const exactCalldata = { calldata: '0x12345678' } as const;
-    const config: FunctionCallUnitOfAuthorityConfig = {
-      environment,
+    const config: FunctionCallScopeConfig = {
+      type: 'functionCall',
       targets: [randomAddress()],
       selectors: ['0x12345678'],
       exactCalldata,
     };
 
-    const caveatBuilder = createFunctionCallCaveatBuilder(config);
+    const caveatBuilder = createFunctionCallCaveatBuilder(environment, config);
 
     const caveats = caveatBuilder.build();
 
@@ -110,9 +110,11 @@ describe('createFunctionCallCaveatBuilder', () => {
   });
 
   it('throws an error for invalid configuration', () => {
-    const config = { environment } as any;
+    const config = {
+      type: 'functionCall',
+    } as unknown as FunctionCallScopeConfig;
 
-    expect(() => createFunctionCallCaveatBuilder(config)).to.throw(
+    expect(() => createFunctionCallCaveatBuilder(environment, config)).to.throw(
       'Invalid Function Call configuration',
     );
   });

--- a/packages/delegation-toolkit/test/caveatBuilder/scope/nativeTokenScope.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/scope/nativeTokenScope.test.ts
@@ -1,10 +1,10 @@
 import { expect } from 'chai';
 import { concat, toHex } from 'viem';
 
-import { createNativeTokenCaveatBuilder } from '../../src/caveatBuilder/nativeTokenUnitOfAuthority';
-import type { NativeTokenUnitOfAuthorityConfig } from '../../src/caveatBuilder/nativeTokenUnitOfAuthority';
-import { randomAddress } from '../utils';
-import type { DeleGatorEnvironment } from 'src';
+import { createNativeTokenCaveatBuilder } from '../../../src/caveatBuilder/scope/nativeTokenScope';
+import type { NativeTokenScopeConfig } from '../../../src/caveatBuilder/scope/nativeTokenScope';
+import type { DeleGatorEnvironment } from '../../../src/types';
+import { randomAddress } from '../../utils';
 
 describe('createNativeTokenCaveatBuilder', () => {
   const environment = {
@@ -17,15 +17,15 @@ describe('createNativeTokenCaveatBuilder', () => {
   } as unknown as DeleGatorEnvironment;
 
   it('creates a Native Token Streaming CaveatBuilder', () => {
-    const config: NativeTokenUnitOfAuthorityConfig = {
-      environment,
+    const config: NativeTokenScopeConfig = {
+      type: 'nativeToken',
       initialAmount: 1000n,
       maxAmount: 10000n,
       amountPerSecond: 1n,
       startTime: Math.floor(Date.now() / 1000),
     };
 
-    const caveatBuilder = createNativeTokenCaveatBuilder(config);
+    const caveatBuilder = createNativeTokenCaveatBuilder(environment, config);
 
     const caveats = caveatBuilder.build();
 
@@ -49,14 +49,14 @@ describe('createNativeTokenCaveatBuilder', () => {
   });
 
   it('creates a Native Token Period Transfer CaveatBuilder', () => {
-    const config: NativeTokenUnitOfAuthorityConfig = {
-      environment,
+    const config: NativeTokenScopeConfig = {
+      type: 'nativeToken',
       periodAmount: 1000n,
       periodDuration: 1000,
       startDate: Math.floor(Date.now() / 1000),
     };
 
-    const caveatBuilder = createNativeTokenCaveatBuilder(config);
+    const caveatBuilder = createNativeTokenCaveatBuilder(environment, config);
 
     const caveats = caveatBuilder.build();
 
@@ -79,12 +79,12 @@ describe('createNativeTokenCaveatBuilder', () => {
   });
 
   it('creates a Native Token Transfer Amount CaveatBuilder', () => {
-    const config: NativeTokenUnitOfAuthorityConfig = {
-      environment,
+    const config: NativeTokenScopeConfig = {
+      type: 'nativeToken',
       maxAmount: 10000n,
     };
 
-    const caveatBuilder = createNativeTokenCaveatBuilder(config);
+    const caveatBuilder = createNativeTokenCaveatBuilder(environment, config);
 
     const caveats = caveatBuilder.build();
 
@@ -103,9 +103,9 @@ describe('createNativeTokenCaveatBuilder', () => {
   });
 
   it('throws an error for invalid configuration', () => {
-    const config = { environment } as any;
+    const config = { type: 'nativeToken' } as unknown as NativeTokenScopeConfig;
 
-    expect(() => createNativeTokenCaveatBuilder(config)).to.throw(
+    expect(() => createNativeTokenCaveatBuilder(environment, config)).to.throw(
       'Invalid native token configuration',
     );
   });

--- a/packages/delegation-toolkit/test/caveatBuilder/scope/ownershipScope.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/scope/ownershipScope.test.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 
-import { createOwnershipTransferCaveatBuilder } from '../../src/caveatBuilder/ownershipUnitOfAuthority';
-import type { OwnershipUnitOfAuthorityConfig } from '../../src/caveatBuilder/ownershipUnitOfAuthority';
-import { randomAddress } from '../utils';
-import type { DeleGatorEnvironment } from 'src';
+import { createOwnershipCaveatBuilder } from '../../../src/caveatBuilder/scope/ownershipScope';
+import type { OwnershipScopeConfig } from '../../../src/caveatBuilder/scope/ownershipScope';
+import type { DeleGatorEnvironment } from '../../../src/types';
+import { randomAddress } from '../../utils';
 
 describe('createOwnershipTransferCaveatBuilder', () => {
   const environment = {
@@ -13,14 +13,12 @@ describe('createOwnershipTransferCaveatBuilder', () => {
   } as unknown as DeleGatorEnvironment;
 
   it('creates an Ownership Transfer CaveatBuilder', () => {
-    const config: OwnershipUnitOfAuthorityConfig = {
+    const config: OwnershipScopeConfig = {
+      type: 'ownership',
       targetContract: randomAddress(),
     };
 
-    const caveatBuilder = createOwnershipTransferCaveatBuilder(
-      environment,
-      config,
-    );
+    const caveatBuilder = createOwnershipCaveatBuilder(environment, config);
 
     const caveats = caveatBuilder.build();
 
@@ -34,10 +32,10 @@ describe('createOwnershipTransferCaveatBuilder', () => {
   });
 
   it('throws an error for invalid configuration', () => {
-    const config: any = {};
+    const config = { type: 'ownership' } as unknown as OwnershipScopeConfig;
 
-    expect(() =>
-      createOwnershipTransferCaveatBuilder(environment, config),
-    ).to.throw('Invalid ownership transfer configuration');
+    expect(() => createOwnershipCaveatBuilder(environment, config)).to.throw(
+      'Invalid ownership transfer configuration',
+    );
   });
 });

--- a/packages/delegation-toolkit/test/caveatBuilder/specificActionERC20TransferBatchBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/specificActionERC20TransferBatchBuilder.test.ts
@@ -21,14 +21,14 @@ describe('specificActionERC20TransferBatchBuilder()', () => {
     firstTarget: Address,
     firstCalldata: `0x${string}`,
   ) => {
-    return specificActionERC20TransferBatchBuilder(
-      environment,
+    const config = {
       tokenAddress,
       recipient,
       amount,
       firstTarget,
       firstCalldata,
-    );
+    };
+    return specificActionERC20TransferBatchBuilder(environment, config);
   };
 
   describe('validation', () => {

--- a/packages/delegation-toolkit/test/caveatBuilder/timestampBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/timestampBuilder.test.ts
@@ -13,10 +13,11 @@ describe('timestampBuilder()', () => {
   } as any as DeleGatorEnvironment;
 
   const buildWithTimestamps = (
-    afterThreshold: number,
-    beforeThreshold: number,
+    timestampAfterThreshold: number,
+    timestampBeforeThreshold: number,
   ) => {
-    return timestampBuilder(environment, afterThreshold, beforeThreshold);
+    const config = { timestampAfterThreshold, timestampBeforeThreshold };
+    return timestampBuilder(environment, config);
   };
 
   describe('validation', () => {

--- a/packages/delegation-toolkit/test/caveatBuilder/valueLteBuilder.test.ts
+++ b/packages/delegation-toolkit/test/caveatBuilder/valueLteBuilder.test.ts
@@ -13,7 +13,8 @@ describe('valueLteEnforcerBuilder()', () => {
   } as any as DeleGatorEnvironment;
 
   const buildWithMaxValue = (maxValue: bigint) => {
-    return valueLteBuilder(environment, maxValue);
+    const config = { maxValue };
+    return valueLteBuilder(environment, config);
   };
 
   describe('validation', () => {

--- a/packages/delegation-toolkit/test/delegation.test.ts
+++ b/packages/delegation-toolkit/test/delegation.test.ts
@@ -255,6 +255,25 @@ describe('createDelegation', () => {
       signature: '0x',
     });
   });
+
+  it('should create a delegation with no additional caveats', () => {
+    const result = createDelegation({
+      environment: delegatorEnvironment,
+      to: mockDelegate,
+      from: mockDelegator,
+      scope: erc20Scope,
+      caveats: [],
+    });
+
+    expect(result).to.deep.equal({
+      delegate: mockDelegate,
+      delegator: mockDelegator,
+      authority: ROOT_AUTHORITY,
+      caveats: [...erc20ScopeCaveats],
+      salt: '0x',
+      signature: '0x',
+    });
+  });
 });
 
 describe('createOpenDelegation', () => {

--- a/packages/delegation-toolkit/test/delegation.test.ts
+++ b/packages/delegation-toolkit/test/delegation.test.ts
@@ -1,6 +1,8 @@
 import { expect } from 'chai';
 import { stub } from 'sinon';
+import { getAddress } from 'viem';
 
+import { randomAddress } from './utils';
 import { resolveCaveats } from '../src/caveatBuilder';
 import {
   type DelegationStruct,
@@ -16,8 +18,6 @@ import {
   signDelegation,
 } from '../src/delegation';
 import type { Caveat, Delegation } from '../src/types';
-import { randomAddress } from './utils';
-import { getAddress } from 'viem';
 
 const mockDelegate = '0x1234567890123456789012345678901234567890' as const;
 const mockDelegator = '0x0987654321098765432109876543210987654321' as const;
@@ -645,7 +645,7 @@ describe('signDelegation', () => {
     });
 
     expect(signature).to.equal('mockSignature');
-    expect(mockSigner.signTypedData.calledOnce).to.be.true;
+    expect(mockSigner.signTypedData.calledOnce).to.equal(true);
   });
 
   it('should throw an error if no caveats are provided and allowInsecureUnrestrictedDelegation is false', async () => {

--- a/packages/delegation-toolkit/test/utils.ts
+++ b/packages/delegation-toolkit/test/utils.ts
@@ -1,5 +1,5 @@
 import hre from 'hardhat';
-import { bytesToHex } from 'viem';
+import { bytesToHex, getAddress } from 'viem';
 import type {
   Chain,
   Hex,
@@ -29,13 +29,16 @@ export const PRIVATE_KEY_Y =
   3540107420755600117661092318610451508057836103782892212756062701855335759222n;
 export const THRESHOLD = 1;
 
-export const randomAddress = (lowerCase = false) => {
+export const randomAddress = (
+  mode: 'lowercase' | 'checksum' | 'none' = 'none',
+) => {
   const address = privateKeyToAddress(generatePrivateKey());
-  if (!lowerCase) {
-    return address;
+  if (mode === 'lowercase') {
+    return address.toLowerCase() as Hex;
+  } else if (mode === 'checksum') {
+    return getAddress(address);
   }
-
-  return address.toLowerCase() as Hex;
+  return address;
 };
 
 export const randomBytes = (byteLength: number): Hex => {

--- a/packages/delegator-e2e/test/caveats/allowedCalldata.test.ts
+++ b/packages/delegator-e2e/test/caveats/allowedCalldata.test.ts
@@ -1,12 +1,13 @@
 import { beforeEach, test, expect } from 'vitest';
 import {
-  createCaveatBuilder,
-  createDelegation,
   createExecution,
+  Delegation,
   Implementation,
+  ROOT_AUTHORITY,
   toMetaMaskSmartAccount,
   type MetaMaskSmartAccount,
 } from '@metamask/delegation-toolkit';
+import { createCaveatBuilder } from '@metamask/delegation-toolkit/utils';
 import {
   encodeExecutionCalldatas,
   encodePermissionContexts,
@@ -139,14 +140,22 @@ const runTest_expectSuccess = async (
 ) => {
   const { environment } = aliceSmartAccount;
 
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
-    caveats: caveats.reduce((builder, caveat) => {
-      builder.addCaveat('allowedCalldata', caveat.from, caveat.calldata);
-      return builder;
-    }, createCaveatBuilder(environment)),
-  });
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
+    authority: ROOT_AUTHORITY,
+    caveats: caveats
+      .reduce((builder, caveat) => {
+        builder.addCaveat('allowedCalldata', {
+          startIndex: caveat.from,
+          value: caveat.calldata,
+        });
+        return builder;
+      }, createCaveatBuilder(environment))
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -207,14 +216,22 @@ const runTest_expectFailure = async (
   caveats: { from: number; calldata: Hex }[],
   expectedError: string,
 ) => {
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
-    caveats: caveats.reduce((builder, caveat) => {
-      builder.addCaveat('allowedCalldata', caveat.from, caveat.calldata);
-      return builder;
-    }, createCaveatBuilder(aliceSmartAccount.environment)),
-  });
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
+    authority: ROOT_AUTHORITY,
+    caveats: caveats
+      .reduce((builder, caveat) => {
+        builder.addCaveat('allowedCalldata', {
+          startIndex: caveat.from,
+          value: caveat.calldata,
+        });
+        return builder;
+      }, createCaveatBuilder(aliceSmartAccount.environment))
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,

--- a/packages/delegator-e2e/test/caveats/allowedMethods.test.ts
+++ b/packages/delegator-e2e/test/caveats/allowedMethods.test.ts
@@ -5,13 +5,14 @@ import {
   SINGLE_DEFAULT_MODE,
 } from '@metamask/delegation-toolkit/utils';
 import {
-  createCaveatBuilder,
   createExecution,
-  createDelegation,
+  Delegation,
   Implementation,
+  ROOT_AUTHORITY,
   toMetaMaskSmartAccount,
   type MetaMaskSmartAccount,
 } from '@metamask/delegation-toolkit';
+import { createCaveatBuilder } from '@metamask/delegation-toolkit/utils';
 import {
   transport,
   gasPrice,
@@ -135,14 +136,16 @@ const runTest_expectSuccess = async (
   allowedMethods: (string | AbiFunction | Hex)[],
   calledMethod: string,
 ) => {
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
-    caveats: createCaveatBuilder(aliceSmartAccount.environment).addCaveat(
-      'allowedMethods',
-      allowedMethods,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(aliceSmartAccount.environment)
+      .addCaveat('allowedMethods', { selectors: allowedMethods })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -201,14 +204,16 @@ const runTest_expectFailure = async (
   calledMethod: string,
   expectedError: string,
 ) => {
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
-    caveats: createCaveatBuilder(aliceSmartAccount.environment).addCaveat(
-      'allowedMethods',
-      allowedMethods,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(aliceSmartAccount.environment)
+      .addCaveat('allowedMethods', { selectors: allowedMethods })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,

--- a/packages/delegator-e2e/test/caveats/allowedTargets.test.ts
+++ b/packages/delegator-e2e/test/caveats/allowedTargets.test.ts
@@ -5,13 +5,14 @@ import {
   SINGLE_DEFAULT_MODE,
 } from '@metamask/delegation-toolkit/utils';
 import {
-  createCaveatBuilder,
   createExecution,
-  createDelegation,
+  Delegation,
   Implementation,
+  ROOT_AUTHORITY,
   toMetaMaskSmartAccount,
   type MetaMaskSmartAccount,
 } from '@metamask/delegation-toolkit';
+import { createCaveatBuilder } from '@metamask/delegation-toolkit/utils';
 import {
   transport,
   gasPrice,
@@ -105,14 +106,16 @@ const runTest_expectSuccess = async (
   allowedTargets: Hex[],
   calledTarget: Hex,
 ) => {
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
-    caveats: createCaveatBuilder(aliceSmartAccount.environment).addCaveat(
-      'allowedTargets',
-      allowedTargets,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(aliceSmartAccount.environment)
+      .addCaveat('allowedTargets', { targets: allowedTargets })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -171,14 +174,16 @@ const runTest_expectFailure = async (
   calledTarget: Hex,
   expectedError: string,
 ) => {
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
-    caveats: createCaveatBuilder(aliceSmartAccount.environment).addCaveat(
-      'allowedTargets',
-      allowedTargets,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(aliceSmartAccount.environment)
+      .addCaveat('allowedTargets', { targets: allowedTargets })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,

--- a/packages/delegator-e2e/test/caveats/argsEqualityCheck.test.ts
+++ b/packages/delegator-e2e/test/caveats/argsEqualityCheck.test.ts
@@ -5,13 +5,14 @@ import {
   SINGLE_DEFAULT_MODE,
 } from '@metamask/delegation-toolkit/utils';
 import {
-  createCaveatBuilder,
   createExecution,
-  createDelegation,
+  Delegation,
   Implementation,
+  ROOT_AUTHORITY,
   toMetaMaskSmartAccount,
   type MetaMaskSmartAccount,
 } from '@metamask/delegation-toolkit';
+import { createCaveatBuilder } from '@metamask/delegation-toolkit/utils';
 import {
   transport,
   gasPrice,
@@ -129,14 +130,16 @@ test('Bob attempts to redeem the delegation with args when none are expected', a
 });
 
 const runTest_expectSuccess = async (expectedArgs: Hex, actualArgs: Hex) => {
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
-    caveats: createCaveatBuilder(aliceSmartAccount.environment).addCaveat(
-      'argsEqualityCheck',
-      expectedArgs,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(aliceSmartAccount.environment)
+      .addCaveat('argsEqualityCheck', { expectedArgs })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -197,14 +200,16 @@ const runTest_expectFailure = async (
   actualArgs: Hex,
   expectedError: string,
 ) => {
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
-    caveats: createCaveatBuilder(aliceSmartAccount.environment).addCaveat(
-      'argsEqualityCheck',
-      expectedArgs,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(aliceSmartAccount.environment)
+      .addCaveat('argsEqualityCheck', { expectedArgs })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,

--- a/packages/delegator-e2e/test/caveats/blockNumber.test.ts
+++ b/packages/delegator-e2e/test/caveats/blockNumber.test.ts
@@ -5,13 +5,14 @@ import {
   SINGLE_DEFAULT_MODE,
 } from '@metamask/delegation-toolkit/utils';
 import {
-  createCaveatBuilder,
   createExecution,
-  createDelegation,
+  Delegation,
   Implementation,
+  ROOT_AUTHORITY,
   toMetaMaskSmartAccount,
   type MetaMaskSmartAccount,
 } from '@metamask/delegation-toolkit';
+import { createCaveatBuilder } from '@metamask/delegation-toolkit/utils';
 import {
   transport,
   gasPrice,
@@ -173,15 +174,19 @@ const runTest_expectSuccess = async (
   afterThreshold: bigint,
   beforeThreshold: bigint,
 ) => {
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
-    caveats: createCaveatBuilder(aliceSmartAccount.environment).addCaveat(
-      'blockNumber',
-      afterThreshold,
-      beforeThreshold,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(aliceSmartAccount.environment)
+      .addCaveat('blockNumber', {
+        blockAfterThreshold: afterThreshold,
+        blockBeforeThreshold: beforeThreshold,
+      })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -243,15 +248,19 @@ const runTest_expectFailure = async (
   beforeThreshold: bigint,
   expectedError: string,
 ) => {
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
-    caveats: createCaveatBuilder(aliceSmartAccount.environment).addCaveat(
-      'blockNumber',
-      afterThreshold,
-      beforeThreshold,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(aliceSmartAccount.environment)
+      .addCaveat('blockNumber', {
+        blockAfterThreshold: afterThreshold,
+        blockBeforeThreshold: beforeThreshold,
+      })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,

--- a/packages/delegator-e2e/test/caveats/deployed.test.ts
+++ b/packages/delegator-e2e/test/caveats/deployed.test.ts
@@ -5,13 +5,14 @@ import {
   SINGLE_DEFAULT_MODE,
 } from '@metamask/delegation-toolkit/utils';
 import {
-  createCaveatBuilder,
-  createDelegation,
   createExecution,
+  Delegation,
   Implementation,
+  ROOT_AUTHORITY,
   toMetaMaskSmartAccount,
   type MetaMaskSmartAccount,
 } from '@metamask/delegation-toolkit';
+import { createCaveatBuilder } from '@metamask/delegation-toolkit/utils';
 import {
   transport,
   gasPrice,
@@ -158,16 +159,20 @@ test('Bob attempts to redeem the delegation, but provides the wrong bytecode', a
 const runTest_expectSuccess = async (deployedAddress: Hex, salt: Hex) => {
   const newCount = hexToBigInt(randomBytes(32));
 
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
-    caveats: createCaveatBuilder(aliceSmartAccount.environment).addCaveat(
-      'deployed',
-      deployedAddress,
-      salt,
-      CounterMetadata.bytecode.object as Hex,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(aliceSmartAccount.environment)
+      .addCaveat('deployed', {
+        contractAddress: deployedAddress,
+        salt,
+        bytecode: CounterMetadata.bytecode.object as Hex,
+      })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -239,16 +244,20 @@ const runTest_expectFailure = async (
 ) => {
   const newCount = hexToBigInt(randomBytes(32));
 
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
-    caveats: createCaveatBuilder(aliceSmartAccount.environment).addCaveat(
-      'deployed',
-      deployedAddress,
-      salt,
-      CounterMetadata.bytecode.object as Hex,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(aliceSmartAccount.environment)
+      .addCaveat('deployed', {
+        contractAddress: deployedAddress,
+        salt,
+        bytecode: CounterMetadata.bytecode.object as Hex,
+      })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,

--- a/packages/delegator-e2e/test/caveats/erc20PeriodTransfer.test.ts
+++ b/packages/delegator-e2e/test/caveats/erc20PeriodTransfer.test.ts
@@ -5,13 +5,14 @@ import {
   SINGLE_DEFAULT_MODE,
 } from '@metamask/delegation-toolkit/utils';
 import {
-  createDelegation,
-  createCaveatBuilder,
   createExecution,
+  Delegation,
   Implementation,
+  ROOT_AUTHORITY,
   toMetaMaskSmartAccount,
   type MetaMaskSmartAccount,
 } from '@metamask/delegation-toolkit';
+import { createCaveatBuilder } from '@metamask/delegation-toolkit/utils';
 import {
   transport,
   gasPrice,
@@ -103,17 +104,21 @@ const runTest_expectSuccess = async (
 ) => {
   const { environment } = aliceSmartAccount;
 
-  const delegation = createDelegation({
-    to: delegate,
-    from: delegator.address,
-    caveats: createCaveatBuilder(environment).addCaveat(
-      'erc20PeriodTransfer',
-      erc20TokenAddress,
-      periodAmount,
-      periodDuration,
-      startDate,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate,
+    delegator: delegator.address,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(environment)
+      .addCaveat('erc20PeriodTransfer', {
+        tokenAddress: erc20TokenAddress,
+        periodAmount,
+        periodDuration,
+        startDate,
+      })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -184,17 +189,21 @@ const runTest_expectFailure = async (
 ) => {
   const { environment } = aliceSmartAccount;
 
-  const delegation = createDelegation({
-    to: delegate,
-    from: delegator.address,
-    caveats: createCaveatBuilder(environment).addCaveat(
-      'erc20PeriodTransfer',
-      erc20TokenAddress,
-      periodAmount,
-      periodDuration,
-      startDate,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate,
+    delegator: delegator.address,
+    caveats: createCaveatBuilder(environment)
+      .addCaveat('erc20PeriodTransfer', {
+        tokenAddress: erc20TokenAddress,
+        periodAmount,
+        periodDuration,
+        startDate,
+      })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+    authority: ROOT_AUTHORITY,
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -332,23 +341,25 @@ test('Bob attempts to redeem with invalid terms length', async () => {
 
   const { environment } = aliceSmartAccount;
   const caveats = createCaveatBuilder(environment)
-    .addCaveat(
-      'erc20PeriodTransfer',
-      erc20TokenAddress,
+    .addCaveat('erc20PeriodTransfer', {
+      tokenAddress: erc20TokenAddress,
       periodAmount,
       periodDuration,
       startDate,
-    )
+    })
     .build();
 
   // Create invalid terms length by appending an empty byte
   caveats[0].terms = concat([caveats[0].terms, '0x00']);
 
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
     caveats,
-  });
+    salt: '0x',
+    signature: '0x',
+    authority: ROOT_AUTHORITY,
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -400,20 +411,22 @@ test('Bob attempts to redeem with invalid execution length', async () => {
 
   const { environment } = aliceSmartAccount;
   const caveats = createCaveatBuilder(environment)
-    .addCaveat(
-      'erc20PeriodTransfer',
-      erc20TokenAddress,
+    .addCaveat('erc20PeriodTransfer', {
+      tokenAddress: erc20TokenAddress,
       periodAmount,
       periodDuration,
       startDate,
-    )
+    })
     .build();
 
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
     caveats,
-  });
+    salt: '0x',
+    signature: '0x',
+    authority: ROOT_AUTHORITY,
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -470,20 +483,22 @@ test('Bob attempts to redeem with invalid contract', async () => {
 
   const { environment } = aliceSmartAccount;
   const caveats = createCaveatBuilder(environment)
-    .addCaveat(
-      'erc20PeriodTransfer',
-      erc20TokenAddress, // valid token address
+    .addCaveat('erc20PeriodTransfer', {
+      tokenAddress: erc20TokenAddress,
       periodAmount,
       periodDuration,
       startDate,
-    )
+    })
     .build();
 
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
     caveats,
-  });
+    salt: '0x',
+    signature: '0x',
+    authority: ROOT_AUTHORITY,
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -536,20 +551,22 @@ test('Bob attempts to redeem with invalid method', async () => {
 
   const { environment } = aliceSmartAccount;
   const caveats = createCaveatBuilder(environment)
-    .addCaveat(
-      'erc20PeriodTransfer',
-      erc20TokenAddress,
+    .addCaveat('erc20PeriodTransfer', {
+      tokenAddress: erc20TokenAddress,
       periodAmount,
       periodDuration,
       startDate,
-    )
+    })
     .build();
 
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
     caveats,
-  });
+    salt: '0x',
+    signature: '0x',
+    authority: ROOT_AUTHORITY,
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -602,13 +619,12 @@ test('Bob attempts to redeem with zero start date', async () => {
 
   const { environment } = aliceSmartAccount;
   const caveats = createCaveatBuilder(environment)
-    .addCaveat(
-      'erc20PeriodTransfer',
-      erc20TokenAddress,
+    .addCaveat('erc20PeriodTransfer', {
+      tokenAddress: erc20TokenAddress,
       periodAmount,
       periodDuration,
-      currentTime, // valid start date
-    )
+      startDate: currentTime,
+    })
     .build();
 
   // Modify the terms to encode zero start date
@@ -619,11 +635,14 @@ test('Bob attempts to redeem with zero start date', async () => {
     `0x${startDate.toString(16).padStart(64, '0')}`, // zero start date
   ]);
 
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
     caveats,
-  });
+    salt: '0x',
+    signature: '0x',
+    authority: ROOT_AUTHORITY,
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -675,13 +694,12 @@ test('Bob attempts to redeem with zero period amount', async () => {
 
   const { environment } = aliceSmartAccount;
   const caveats = createCaveatBuilder(environment)
-    .addCaveat(
-      'erc20PeriodTransfer',
-      erc20TokenAddress,
-      1n, // valid period amount
+    .addCaveat('erc20PeriodTransfer', {
+      tokenAddress: erc20TokenAddress,
+      periodAmount: 1n,
       periodDuration,
       startDate,
-    )
+    })
     .build();
 
   // Modify the terms to encode zero period amount
@@ -692,11 +710,14 @@ test('Bob attempts to redeem with zero period amount', async () => {
     `0x${startDate.toString(16).padStart(64, '0')}`, // startDate
   ]);
 
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
     caveats,
-  });
+    salt: '0x',
+    signature: '0x',
+    authority: ROOT_AUTHORITY,
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -748,13 +769,12 @@ test('Bob attempts to redeem with zero period duration', async () => {
 
   const { environment } = aliceSmartAccount;
   const caveats = createCaveatBuilder(environment)
-    .addCaveat(
-      'erc20PeriodTransfer',
-      erc20TokenAddress,
+    .addCaveat('erc20PeriodTransfer', {
+      tokenAddress: erc20TokenAddress,
       periodAmount,
-      3600, // valid period duration
+      periodDuration,
       startDate,
-    )
+    })
     .build();
 
   // Modify the terms to encode zero period duration
@@ -765,11 +785,14 @@ test('Bob attempts to redeem with zero period duration', async () => {
     `0x${startDate.toString(16).padStart(64, '0')}`, // startDate
   ]);
 
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
     caveats,
-  });
+    salt: '0x',
+    signature: '0x',
+    authority: ROOT_AUTHORITY,
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -821,20 +844,22 @@ test('Bob attempts to redeem before start date', async () => {
 
   const { environment } = aliceSmartAccount;
   const caveats = createCaveatBuilder(environment)
-    .addCaveat(
-      'erc20PeriodTransfer',
-      erc20TokenAddress,
+    .addCaveat('erc20PeriodTransfer', {
+      tokenAddress: erc20TokenAddress,
       periodAmount,
       periodDuration,
       startDate,
-    )
+    })
     .build();
 
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
     caveats,
-  });
+    salt: '0x',
+    signature: '0x',
+    authority: ROOT_AUTHORITY,
+  };
 
   const signedDelegation = {
     ...delegation,

--- a/packages/delegator-e2e/test/caveats/erc20Streaming.test.ts
+++ b/packages/delegator-e2e/test/caveats/erc20Streaming.test.ts
@@ -3,15 +3,16 @@ import {
   encodeExecutionCalldatas,
   encodePermissionContexts,
   SINGLE_DEFAULT_MODE,
+  createCaveatBuilder,
 } from '@metamask/delegation-toolkit/utils';
 import {
-  createCaveatBuilder,
   createExecution,
-  createDelegation,
   Implementation,
   toMetaMaskSmartAccount,
   type MetaMaskSmartAccount,
   type ExecutionStruct,
+  ROOT_AUTHORITY,
+  Delegation,
 } from '@metamask/delegation-toolkit';
 import {
   transport,
@@ -389,24 +390,26 @@ test('Bob attempts to redeem with invalid terms length', async () => {
 
   const { environment } = aliceSmartAccount;
   const caveats = createCaveatBuilder(environment)
-    .addCaveat(
-      'erc20Streaming',
-      erc20TokenAddress,
+    .addCaveat('erc20Streaming', {
+      tokenAddress: erc20TokenAddress,
       initialAmount,
       maxAmount,
       amountPerSecond,
       startTime,
-    )
+    })
     .build();
 
   // create invalid terms length by appending an empty byte
   caveats[0].terms = concat([caveats[0].terms, '0x00']);
 
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
     caveats,
-  });
+    salt: '0x',
+    signature: '0x',
+    authority: ROOT_AUTHORITY,
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -461,14 +464,13 @@ test('Bob attempts to redeem with maxAmount less than initialAmount', async () =
 
   const { environment } = aliceSmartAccount;
   const caveats = createCaveatBuilder(environment)
-    .addCaveat(
-      'erc20Streaming',
-      erc20TokenAddress,
-      0n, // valid initialAmount
-      1n, // valid maxAmount
+    .addCaveat('erc20Streaming', {
+      tokenAddress: erc20TokenAddress,
+      initialAmount: 0n,
+      maxAmount: 1n,
       amountPerSecond,
       startTime,
-    )
+    })
     .build();
 
   // Modify the terms to encode maxAmount < initialAmount
@@ -480,11 +482,14 @@ test('Bob attempts to redeem with maxAmount less than initialAmount', async () =
     `0x${startTime.toString(16).padStart(64, '0')}`, // startTime
   ]);
 
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
     caveats,
-  });
+    salt: '0x',
+    signature: '0x',
+    authority: ROOT_AUTHORITY,
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -539,14 +544,13 @@ test('Bob attempts to redeem with zero start time', async () => {
 
   const { environment } = aliceSmartAccount;
   const caveats = createCaveatBuilder(environment)
-    .addCaveat(
-      'erc20Streaming',
-      erc20TokenAddress,
+    .addCaveat('erc20Streaming', {
+      tokenAddress: erc20TokenAddress,
       initialAmount,
       maxAmount,
       amountPerSecond,
-      currentTime, // valid start time
-    )
+      startTime: currentTime,
+    })
     .build();
 
   // Modify the terms to encode zero start time
@@ -558,11 +562,14 @@ test('Bob attempts to redeem with zero start time', async () => {
     `0x${startTime.toString(16).padStart(64, '0')}`, // zero start time
   ]);
 
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
     caveats,
-  });
+    salt: '0x',
+    signature: '0x',
+    authority: ROOT_AUTHORITY,
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -618,18 +625,22 @@ const runTest_expectSuccess = async (
 ) => {
   const { environment } = aliceSmartAccount;
 
-  const delegation = createDelegation({
-    to: delegate,
-    from: delegator.address,
-    caveats: createCaveatBuilder(environment).addCaveat(
-      'erc20Streaming',
-      erc20TokenAddress,
-      initialAmount,
-      maxAmount,
-      amountPerSecond,
-      startTime,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate,
+    delegator: delegator.address,
+    caveats: createCaveatBuilder(environment)
+      .addCaveat('erc20Streaming', {
+        tokenAddress: erc20TokenAddress,
+        initialAmount,
+        maxAmount,
+        amountPerSecond,
+        startTime,
+      })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+    authority: ROOT_AUTHORITY,
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -705,18 +716,22 @@ const runTest_expectFailure = async (
 ) => {
   const { environment } = aliceSmartAccount;
 
-  const delegation = createDelegation({
-    to: delegate,
-    from: delegator.address,
-    caveats: createCaveatBuilder(environment).addCaveat(
-      'erc20Streaming',
-      erc20TokenAddress,
-      initialAmount,
-      maxAmount,
-      amountPerSecond,
-      startTime,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate,
+    delegator: delegator.address,
+    caveats: createCaveatBuilder(environment)
+      .addCaveat('erc20Streaming', {
+        tokenAddress: erc20TokenAddress,
+        initialAmount,
+        maxAmount,
+        amountPerSecond,
+        startTime,
+      })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+    authority: ROOT_AUTHORITY,
+  };
 
   const signedDelegation = {
     ...delegation,

--- a/packages/delegator-e2e/test/caveats/exactCalldata.test.ts
+++ b/packages/delegator-e2e/test/caveats/exactCalldata.test.ts
@@ -1,12 +1,13 @@
 import { beforeEach, test, expect } from 'vitest';
 import {
-  createCaveatBuilder,
   createExecution,
-  createDelegation,
+  Delegation,
   Implementation,
+  ROOT_AUTHORITY,
   toMetaMaskSmartAccount,
   type MetaMaskSmartAccount,
 } from '@metamask/delegation-toolkit';
+import { createCaveatBuilder } from '@metamask/delegation-toolkit/utils';
 import {
   encodePermissionContexts,
   encodeExecutionCalldatas,
@@ -81,14 +82,16 @@ const runTest_expectSuccess = async (
 ) => {
   const { environment } = aliceSmartAccount;
 
-  const delegation = createDelegation({
-    to: delegate,
-    from: delegator.address,
-    caveats: createCaveatBuilder(environment).addCaveat(
-      'exactCalldata',
-      calldata,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: delegate,
+    delegator: delegator.address,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(environment)
+      .addCaveat('exactCalldata', { calldata })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -139,14 +142,16 @@ const runTest_expectFailure = async (
 ) => {
   const { environment } = aliceSmartAccount;
 
-  const delegation = createDelegation({
-    to: delegate,
-    from: delegator.address,
-    caveats: createCaveatBuilder(environment).addCaveat(
-      'exactCalldata',
-      expectedCalldata,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: delegate,
+    delegator: delegator.address,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(environment)
+      .addCaveat('exactCalldata', { calldata: expectedCalldata })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,

--- a/packages/delegator-e2e/test/caveats/exactCalldataBatch.test.ts
+++ b/packages/delegator-e2e/test/caveats/exactCalldataBatch.test.ts
@@ -1,12 +1,13 @@
 import { beforeEach, test, expect } from 'vitest';
 import {
-  createCaveatBuilder,
-  createDelegation,
+  Delegation,
   Implementation,
+  ROOT_AUTHORITY,
   toMetaMaskSmartAccount,
   type MetaMaskSmartAccount,
   type ExecutionStruct,
 } from '@metamask/delegation-toolkit';
+import { createCaveatBuilder } from '@metamask/delegation-toolkit/utils';
 import {
   BATCH_DEFAULT_MODE,
   encodeExecutionCalldatas,
@@ -78,14 +79,16 @@ const runTest_expectSuccess = async (
 ) => {
   const { environment } = aliceSmartAccount;
 
-  const delegation = createDelegation({
-    to: delegate,
-    from: delegator.address,
-    caveats: createCaveatBuilder(environment).addCaveat(
-      'exactCalldataBatch',
-      expectedExecutions,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: delegate,
+    delegator: delegator.address,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(environment)
+      .addCaveat('exactCalldataBatch', { executions: expectedExecutions })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -131,14 +134,16 @@ const runTest_expectFailure = async (
 ) => {
   const { environment } = aliceSmartAccount;
 
-  const delegation = createDelegation({
-    to: delegate,
-    from: delegator.address,
-    caveats: createCaveatBuilder(environment).addCaveat(
-      'exactCalldataBatch',
-      expectedExecutions,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: delegate,
+    delegator: delegator.address,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(environment)
+      .addCaveat('exactCalldataBatch', { executions: expectedExecutions })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,

--- a/packages/delegator-e2e/test/caveats/exactExecution.test.ts
+++ b/packages/delegator-e2e/test/caveats/exactExecution.test.ts
@@ -5,13 +5,14 @@ import {
   SINGLE_DEFAULT_MODE,
 } from '@metamask/delegation-toolkit/utils';
 import {
-  createDelegation,
-  createCaveatBuilder,
+  Delegation,
   Implementation,
+  ROOT_AUTHORITY,
   toMetaMaskSmartAccount,
   type ExecutionStruct,
   type MetaMaskSmartAccount,
 } from '@metamask/delegation-toolkit';
+import { createCaveatBuilder } from '@metamask/delegation-toolkit/utils';
 
 import {
   transport,
@@ -74,14 +75,16 @@ const runTest_expectSuccess = async (
 ) => {
   const { environment } = aliceSmartAccount;
 
-  const delegation = createDelegation({
-    to: delegate,
-    from: delegator.address,
-    caveats: createCaveatBuilder(environment).addCaveat(
-      'exactExecution',
-      execution,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: delegate,
+    delegator: delegator.address,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(environment)
+      .addCaveat('exactExecution', { execution })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -127,14 +130,16 @@ const runTest_expectFailure = async (
 ) => {
   const { environment } = aliceSmartAccount;
 
-  const delegation = createDelegation({
-    to: delegate,
-    from: delegator.address,
-    caveats: createCaveatBuilder(environment).addCaveat(
-      'exactExecution',
-      expectedExecution,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: delegate,
+    delegator: delegator.address,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(environment)
+      .addCaveat('exactExecution', { execution: expectedExecution })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,

--- a/packages/delegator-e2e/test/caveats/exactExecutionBatch.test.ts
+++ b/packages/delegator-e2e/test/caveats/exactExecutionBatch.test.ts
@@ -5,13 +5,14 @@ import {
   BATCH_DEFAULT_MODE,
 } from '@metamask/delegation-toolkit/utils';
 import {
-  createDelegation,
-  createCaveatBuilder,
+  Delegation,
   Implementation,
+  ROOT_AUTHORITY,
   toMetaMaskSmartAccount,
   type ExecutionStruct,
   type MetaMaskSmartAccount,
 } from '@metamask/delegation-toolkit';
+import { createCaveatBuilder } from '@metamask/delegation-toolkit/utils';
 import {
   transport,
   gasPrice,
@@ -76,14 +77,16 @@ const runTest_expectSuccess = async (
 ) => {
   const { environment } = aliceSmartAccount;
 
-  const delegation = createDelegation({
-    to: delegate,
-    from: delegator.address,
-    caveats: createCaveatBuilder(environment).addCaveat(
-      'exactExecutionBatch',
-      executions,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: delegate,
+    delegator: delegator.address,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(environment)
+      .addCaveat('exactExecutionBatch', { executions })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -129,14 +132,16 @@ const runTest_expectFailure = async (
 ) => {
   const { environment } = aliceSmartAccount;
 
-  const delegation = createDelegation({
-    to: delegate,
-    from: delegator.address,
-    caveats: createCaveatBuilder(environment).addCaveat(
-      'exactExecutionBatch',
-      expectedExecutions,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: delegate,
+    delegator: delegator.address,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(environment)
+      .addCaveat('exactExecutionBatch', { executions: expectedExecutions })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,

--- a/packages/delegator-e2e/test/caveats/id.test.ts
+++ b/packages/delegator-e2e/test/caveats/id.test.ts
@@ -5,13 +5,14 @@ import {
   SINGLE_DEFAULT_MODE,
 } from '@metamask/delegation-toolkit/utils';
 import {
-  createCaveatBuilder,
-  createDelegation,
   createExecution,
+  Delegation,
   Implementation,
+  ROOT_AUTHORITY,
   toMetaMaskSmartAccount,
   type MetaMaskSmartAccount,
 } from '@metamask/delegation-toolkit';
+import { createCaveatBuilder } from '@metamask/delegation-toolkit/utils';
 
 import {
   transport,
@@ -104,17 +105,19 @@ test('Bob attempts to redeem a second delegation with the same id', async () => 
   await runTest_expectFailure(id, 'IdEnforcer:id-already-used');
 });
 
-const runTest_expectSuccess = async (id: number) => {
+const runTest_expectSuccess = async (idValue: number) => {
   const newCount = hexToBigInt(randomBytes(32));
 
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
-    caveats: createCaveatBuilder(aliceSmartAccount.environment).addCaveat(
-      'id',
-      id,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(aliceSmartAccount.environment)
+      .addCaveat('id', { idValue })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -170,17 +173,22 @@ const runTest_expectSuccess = async (id: number) => {
   expect(countAfter).toEqual(newCount);
 };
 
-const runTest_expectFailure = async (id: number, expectedError: string) => {
+const runTest_expectFailure = async (
+  idValue: number,
+  expectedError: string,
+) => {
   const newCount = hexToBigInt(randomBytes(32));
 
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
-    caveats: createCaveatBuilder(aliceSmartAccount.environment).addCaveat(
-      'id',
-      id,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(aliceSmartAccount.environment)
+      .addCaveat('id', { idValue })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,

--- a/packages/delegator-e2e/test/caveats/limitedCalls.test.ts
+++ b/packages/delegator-e2e/test/caveats/limitedCalls.test.ts
@@ -5,13 +5,14 @@ import {
   SINGLE_DEFAULT_MODE,
 } from '@metamask/delegation-toolkit/utils';
 import {
-  createCaveatBuilder,
-  createDelegation,
   createExecution,
+  Delegation,
   Implementation,
+  ROOT_AUTHORITY,
   toMetaMaskSmartAccount,
   type MetaMaskSmartAccount,
 } from '@metamask/delegation-toolkit';
+import { createCaveatBuilder } from '@metamask/delegation-toolkit/utils';
 
 import {
   transport,
@@ -95,14 +96,16 @@ const runTest_expectFailure = async (
 };
 
 const runTest = async (limit: number, runs: number) => {
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
-    caveats: createCaveatBuilder(aliceSmartAccount.environment).addCaveat(
-      'limitedCalls',
-      limit,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(aliceSmartAccount.environment)
+      .addCaveat('limitedCalls', { limit })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,

--- a/packages/delegator-e2e/test/caveats/multiTokenPeriod.test.ts
+++ b/packages/delegator-e2e/test/caveats/multiTokenPeriod.test.ts
@@ -5,13 +5,14 @@ import {
   SINGLE_DEFAULT_MODE,
 } from '@metamask/delegation-toolkit/utils';
 import {
-  createDelegation,
-  createCaveatBuilder,
   createExecution,
+  Delegation,
   Implementation,
+  ROOT_AUTHORITY,
   toMetaMaskSmartAccount,
   type MetaMaskSmartAccount,
 } from '@metamask/delegation-toolkit';
+import { createCaveatBuilder } from '@metamask/delegation-toolkit/utils';
 import {
   transport,
   gasPrice,
@@ -123,14 +124,16 @@ const runTest_expectSuccess = async (
 ) => {
   const { environment } = aliceSmartAccount;
 
-  const delegation = createDelegation({
-    to: delegate,
-    from: delegator.address,
-    caveats: createCaveatBuilder(environment).addCaveat(
-      'multiTokenPeriod',
-      configs,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: delegate,
+    delegator: delegator.address,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(environment)
+      .addCaveat('multiTokenPeriod', configs)
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   if (!delegation.caveats[0]) {
     throw new Error('MultiTokenPeriod caveat not found');
@@ -209,14 +212,16 @@ const runTest_expectFailure = async (
 ) => {
   const { environment } = aliceSmartAccount;
 
-  const delegation = createDelegation({
-    to: delegate,
-    from: delegator.address,
-    caveats: createCaveatBuilder(environment).addCaveat(
-      'multiTokenPeriod',
-      configs,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: delegate,
+    delegator: delegator.address,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(environment)
+      .addCaveat('multiTokenPeriod', configs)
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   if (!delegation.caveats[0]) {
     throw new Error('MultiTokenPeriod caveat not found');

--- a/packages/delegator-e2e/test/caveats/nativeTokenPayment.test.ts
+++ b/packages/delegator-e2e/test/caveats/nativeTokenPayment.test.ts
@@ -142,7 +142,7 @@ test('Bob attempts to redeem the delegation without an argsEqualityCheckEnforcer
     to: bobSmartAccount.environment.caveatEnforcers.NativeTokenPaymentEnforcer!,
     from: bobSmartAccount.address,
     caveats: createCaveatBuilder(aliceSmartAccount.environment, {
-      allowEmptyCaveats: true,
+      allowInsecureUnrestrictedDelegation: true,
     }),
   });
 

--- a/packages/delegator-e2e/test/caveats/nativeTokenPeriodTransfer.test.ts
+++ b/packages/delegator-e2e/test/caveats/nativeTokenPeriodTransfer.test.ts
@@ -3,13 +3,14 @@ import {
   encodeExecutionCalldatas,
   encodePermissionContexts,
   SINGLE_DEFAULT_MODE,
+  createCaveatBuilder,
 } from '@metamask/delegation-toolkit/utils';
 import {
-  createDelegation,
-  createCaveatBuilder,
   Implementation,
   toMetaMaskSmartAccount,
   type MetaMaskSmartAccount,
+  ROOT_AUTHORITY,
+  type Delegation,
 } from '@metamask/delegation-toolkit';
 
 import {
@@ -85,16 +86,20 @@ const runTest_expectSuccess = async (
 ) => {
   const { environment } = aliceSmartAccount;
 
-  const delegation = createDelegation({
-    to: delegate,
-    from: delegator.address,
-    caveats: createCaveatBuilder(environment).addCaveat(
-      'nativeTokenPeriodTransfer',
-      periodAmount,
-      periodDuration,
-      startDate,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate,
+    delegator: delegator.address,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(environment)
+      .addCaveat('nativeTokenPeriodTransfer', {
+        periodAmount,
+        periodDuration,
+        startDate,
+      })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -155,16 +160,20 @@ const runTest_expectFailure = async (
 ) => {
   const { environment } = aliceSmartAccount;
 
-  const delegation = createDelegation({
-    to: delegate,
-    from: delegator.address,
-    caveats: createCaveatBuilder(environment).addCaveat(
-      'nativeTokenPeriodTransfer',
-      periodAmount,
-      periodDuration,
-      startDate,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate,
+    delegator: delegator.address,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(environment)
+      .addCaveat('nativeTokenPeriodTransfer', {
+        periodAmount,
+        periodDuration,
+        startDate,
+      })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -288,22 +297,24 @@ test('Bob attempts to redeem with invalid terms length', async () => {
 
   const { environment } = aliceSmartAccount;
   const caveats = createCaveatBuilder(environment)
-    .addCaveat(
-      'nativeTokenPeriodTransfer',
+    .addCaveat('nativeTokenPeriodTransfer', {
       periodAmount,
       periodDuration,
       startDate,
-    )
+    })
     .build();
 
   // Create invalid terms length by appending an empty byte
   caveats[0].terms = concat([caveats[0].terms, '0x00']);
 
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
+    authority: ROOT_AUTHORITY,
     caveats,
-  });
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -348,12 +359,11 @@ test('Bob attempts to redeem with zero start date', async () => {
 
   const { environment } = aliceSmartAccount;
   const caveats = createCaveatBuilder(environment)
-    .addCaveat(
-      'nativeTokenPeriodTransfer',
+    .addCaveat('nativeTokenPeriodTransfer', {
       periodAmount,
       periodDuration,
-      currentTime, // valid start date
-    )
+      startDate: currentTime, // valid start date
+    })
     .build();
 
   // Modify the terms to encode zero start date
@@ -363,11 +373,14 @@ test('Bob attempts to redeem with zero start date', async () => {
     `0x${startDate.toString(16).padStart(64, '0')}`, // zero start date
   ]);
 
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
+    authority: ROOT_AUTHORITY,
     caveats,
-  });
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -414,12 +427,11 @@ test('Bob attempts to redeem with zero period amount', async () => {
 
   const { environment } = aliceSmartAccount;
   const caveats = createCaveatBuilder(environment)
-    .addCaveat(
-      'nativeTokenPeriodTransfer',
-      1n, // valid period amount
+    .addCaveat('nativeTokenPeriodTransfer', {
+      periodAmount: 1n, // valid period amount
       periodDuration,
       startDate,
-    )
+    })
     .build();
 
   // Modify the terms to encode zero period amount
@@ -429,11 +441,14 @@ test('Bob attempts to redeem with zero period amount', async () => {
     `0x${startDate.toString(16).padStart(64, '0')}`, // startDate
   ]);
 
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
+    authority: ROOT_AUTHORITY,
     caveats,
-  });
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -480,12 +495,11 @@ test('Bob attempts to redeem with zero period duration', async () => {
 
   const { environment } = aliceSmartAccount;
   const caveats = createCaveatBuilder(environment)
-    .addCaveat(
-      'nativeTokenPeriodTransfer',
+    .addCaveat('nativeTokenPeriodTransfer', {
       periodAmount,
-      3600, // valid period duration
+      periodDuration: 3600, // valid period duration
       startDate,
-    )
+    })
     .build();
 
   // Modify the terms to encode zero period duration
@@ -495,11 +509,14 @@ test('Bob attempts to redeem with zero period duration', async () => {
     `0x${startDate.toString(16).padStart(64, '0')}`, // startDate
   ]);
 
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
+    authority: ROOT_AUTHORITY,
     caveats,
-  });
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -546,19 +563,21 @@ test('Bob attempts to redeem before start date', async () => {
 
   const { environment } = aliceSmartAccount;
   const caveats = createCaveatBuilder(environment)
-    .addCaveat(
-      'nativeTokenPeriodTransfer',
+    .addCaveat('nativeTokenPeriodTransfer', {
       periodAmount,
       periodDuration,
       startDate,
-    )
+    })
     .build();
 
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
+    authority: ROOT_AUTHORITY,
     caveats,
-  });
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,

--- a/packages/delegator-e2e/test/caveats/nativeTokenStreaming.test.ts
+++ b/packages/delegator-e2e/test/caveats/nativeTokenStreaming.test.ts
@@ -3,14 +3,15 @@ import {
   encodeExecutionCalldatas,
   encodePermissionContexts,
   SINGLE_DEFAULT_MODE,
+  createCaveatBuilder,
 } from '@metamask/delegation-toolkit/utils';
 import {
-  createCaveatBuilder,
   createExecution,
-  createDelegation,
+  ROOT_AUTHORITY,
   Implementation,
   toMetaMaskSmartAccount,
   type MetaMaskSmartAccount,
+  Delegation,
 } from '@metamask/delegation-toolkit';
 
 import {
@@ -315,23 +316,25 @@ test('Bob attempts to redeem with invalid terms length', async () => {
 
   const { environment } = aliceSmartAccount;
   const caveats = createCaveatBuilder(environment)
-    .addCaveat(
-      'nativeTokenStreaming',
+    .addCaveat('nativeTokenStreaming', {
       initialAmount,
       maxAmount,
       amountPerSecond,
       startTime,
-    )
+    })
     .build();
 
   // Create invalid terms length by appending an empty byte
   caveats[0].terms = concat([caveats[0].terms, '0x00']);
 
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
     caveats,
-  });
+    salt: '0x',
+    signature: '0x',
+    authority: ROOT_AUTHORITY,
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -380,13 +383,12 @@ test('Bob attempts to redeem with invalid max amount', async () => {
 
   const { environment } = aliceSmartAccount;
   const caveats = createCaveatBuilder(environment)
-    .addCaveat(
-      'nativeTokenStreaming',
+    .addCaveat('nativeTokenStreaming', {
       initialAmount,
-      parseEther('20'), // valid maxAmount
+      maxAmount: parseEther('20'), // valid maxAmount
       amountPerSecond,
       startTime,
-    )
+    })
     .build();
 
   caveats[0].terms = concat([
@@ -396,11 +398,14 @@ test('Bob attempts to redeem with invalid max amount', async () => {
     `0x${startTime.toString(16).padStart(64, '0')}`, // zero start time
   ]);
 
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
     caveats,
-  });
+    salt: '0x',
+    signature: '0x',
+    authority: ROOT_AUTHORITY,
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -449,13 +454,12 @@ test('Bob attempts to redeem with zero start time', async () => {
 
   const { environment } = aliceSmartAccount;
   const caveats = createCaveatBuilder(environment)
-    .addCaveat(
-      'nativeTokenStreaming',
+    .addCaveat('nativeTokenStreaming', {
       initialAmount,
       maxAmount,
       amountPerSecond,
-      currentTime, // valid start time
-    )
+      startTime: currentTime, // valid start time
+    })
     .build();
 
   // Modify the terms to encode zero start time
@@ -466,11 +470,14 @@ test('Bob attempts to redeem with zero start time', async () => {
     `0x${startTime.toString(16).padStart(64, '0')}`, // zero start time
   ]);
 
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
     caveats,
-  });
+    salt: '0x',
+    signature: '0x',
+    authority: ROOT_AUTHORITY,
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -520,17 +527,21 @@ const runTest_expectSuccess = async (
 ) => {
   const { environment } = aliceSmartAccount;
 
-  const delegation = createDelegation({
-    to: delegate,
-    from: delegator.address,
-    caveats: createCaveatBuilder(environment).addCaveat(
-      'nativeTokenStreaming',
-      initialAmount,
-      maxAmount,
-      amountPerSecond,
-      startTime,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate,
+    delegator: delegator.address,
+    caveats: createCaveatBuilder(environment)
+      .addCaveat('nativeTokenStreaming', {
+        initialAmount,
+        maxAmount,
+        amountPerSecond,
+        startTime,
+      })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+    authority: ROOT_AUTHORITY,
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -598,17 +609,21 @@ const runTest_expectFailure = async (
 ) => {
   const { environment } = aliceSmartAccount;
 
-  const delegation = createDelegation({
-    to: delegate,
-    from: delegator.address,
-    caveats: createCaveatBuilder(environment).addCaveat(
-      'nativeTokenStreaming',
-      initialAmount,
-      maxAmount,
-      amountPerSecond,
-      startTime,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate,
+    delegator: delegator.address,
+    caveats: createCaveatBuilder(environment)
+      .addCaveat('nativeTokenStreaming', {
+        initialAmount,
+        maxAmount,
+        amountPerSecond,
+        startTime,
+      })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+    authority: ROOT_AUTHORITY,
+  };
 
   const signedDelegation = {
     ...delegation,

--- a/packages/delegator-e2e/test/caveats/nativeTokenTransferAmount.test.ts
+++ b/packages/delegator-e2e/test/caveats/nativeTokenTransferAmount.test.ts
@@ -5,13 +5,14 @@ import {
   SINGLE_DEFAULT_MODE,
 } from '@metamask/delegation-toolkit/utils';
 import {
-  createCaveatBuilder,
-  createDelegation,
   createExecution,
+  Delegation,
   Implementation,
+  ROOT_AUTHORITY,
   toMetaMaskSmartAccount,
   type MetaMaskSmartAccount,
 } from '@metamask/delegation-toolkit';
+import { createCaveatBuilder } from '@metamask/delegation-toolkit/utils';
 import {
   transport,
   gasPrice,
@@ -85,14 +86,16 @@ const runTest_expectSuccess = async (
   const bobAddress = bobSmartAccount.address;
   const aliceAddress = aliceSmartAccount.address;
 
-  const delegation = createDelegation({
-    to: bobAddress,
-    from: aliceAddress,
-    caveats: createCaveatBuilder(aliceSmartAccount.environment).addCaveat(
-      'nativeTokenTransferAmount',
-      allowance,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: bobAddress,
+    delegator: aliceAddress,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(aliceSmartAccount.environment)
+      .addCaveat('nativeTokenTransferAmount', { maxAmount: allowance })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -155,14 +158,16 @@ const runTest_expectFailure = async (
   const bobAddress = bobSmartAccount.address;
   const aliceAddress = aliceSmartAccount.address;
 
-  const delegation = createDelegation({
-    to: bobAddress,
-    from: aliceAddress,
-    caveats: createCaveatBuilder(aliceSmartAccount.environment).addCaveat(
-      'nativeTokenTransferAmount',
-      allowance,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: bobAddress,
+    delegator: aliceAddress,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(aliceSmartAccount.environment)
+      .addCaveat('nativeTokenTransferAmount', { maxAmount: allowance })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,

--- a/packages/delegator-e2e/test/caveats/nonce.test.ts
+++ b/packages/delegator-e2e/test/caveats/nonce.test.ts
@@ -6,13 +6,14 @@ import {
   SINGLE_DEFAULT_MODE,
 } from '@metamask/delegation-toolkit/utils';
 import {
-  createCaveatBuilder,
-  createDelegation,
   createExecution,
+  Delegation,
   Implementation,
+  ROOT_AUTHORITY,
   toMetaMaskSmartAccount,
   type MetaMaskSmartAccount,
 } from '@metamask/delegation-toolkit';
+import { createCaveatBuilder } from '@metamask/delegation-toolkit/utils';
 import {
   transport,
   gasPrice,
@@ -116,14 +117,16 @@ const runTest_expectSuccess = async (newCount: bigint, nonce: bigint) => {
   const bobAddress = bobSmartAccount.address;
   const aliceAddress = aliceSmartAccount.address;
 
-  const delegation = createDelegation({
-    to: bobAddress,
-    from: aliceAddress,
-    caveats: createCaveatBuilder(aliceSmartAccount.environment).addCaveat(
-      'nonce',
-      toHex(nonce),
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: bobAddress,
+    delegator: aliceAddress,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(aliceSmartAccount.environment)
+      .addCaveat('nonce', { nonceValue: toHex(nonce) })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -186,14 +189,16 @@ const runTest_expectFailure = async (
   const bobAddress = bobSmartAccount.address;
   const aliceAddress = aliceSmartAccount.address;
 
-  const delegation = createDelegation({
-    to: bobAddress,
-    from: aliceAddress,
-    caveats: createCaveatBuilder(aliceSmartAccount.environment).addCaveat(
-      'nonce',
-      toHex(nonce),
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: bobAddress,
+    delegator: aliceAddress,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(aliceSmartAccount.environment)
+      .addCaveat('nonce', { nonceValue: toHex(nonce) })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,

--- a/packages/delegator-e2e/test/caveats/redeemer.test.ts
+++ b/packages/delegator-e2e/test/caveats/redeemer.test.ts
@@ -5,13 +5,14 @@ import {
   SINGLE_DEFAULT_MODE,
 } from '@metamask/delegation-toolkit/utils';
 import {
-  createCaveatBuilder,
-  createDelegation,
   createExecution,
+  Delegation,
   Implementation,
+  ROOT_AUTHORITY,
   toMetaMaskSmartAccount,
   type MetaMaskSmartAccount,
 } from '@metamask/delegation-toolkit';
+import { createCaveatBuilder } from '@metamask/delegation-toolkit/utils';
 
 import {
   transport,
@@ -92,14 +93,16 @@ const runTest_expectSuccess = async (
   const bobAddress = bobSmartAccount.address;
   const aliceAddress = aliceSmartAccount.address;
 
-  const delegation = createDelegation({
-    to: bobAddress,
-    from: aliceAddress,
-    caveats: createCaveatBuilder(aliceSmartAccount.environment).addCaveat(
-      'redeemer',
-      allowedRedeemers,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: bobAddress,
+    delegator: aliceAddress,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(aliceSmartAccount.environment)
+      .addCaveat('redeemer', { redeemers: allowedRedeemers })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -169,14 +172,16 @@ const runTest_expectFailure = async (
   const bobAddress = bobSmartAccount.address;
   const aliceAddress = aliceSmartAccount.address;
 
-  const delegation = createDelegation({
-    to: bobAddress,
-    from: aliceAddress,
-    caveats: createCaveatBuilder(aliceSmartAccount.environment).addCaveat(
-      'redeemer',
-      allowedRedeemers,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: bobAddress,
+    delegator: aliceAddress,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(aliceSmartAccount.environment)
+      .addCaveat('redeemer', { redeemers: allowedRedeemers })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,

--- a/packages/delegator-e2e/test/caveats/specificActionERC20TransferBatch.test.ts
+++ b/packages/delegator-e2e/test/caveats/specificActionERC20TransferBatch.test.ts
@@ -5,13 +5,14 @@ import {
   encodePermissionContexts,
 } from '@metamask/delegation-toolkit/utils';
 import {
-  createDelegation,
-  createCaveatBuilder,
+  Delegation,
   Implementation,
+  ROOT_AUTHORITY,
   toMetaMaskSmartAccount,
   type ExecutionStruct,
   type MetaMaskSmartAccount,
 } from '@metamask/delegation-toolkit';
+import { createCaveatBuilder } from '@metamask/delegation-toolkit/utils';
 
 import {
   transport,
@@ -93,18 +94,22 @@ const runTest_expectSuccess = async (
 ) => {
   const { environment } = aliceSmartAccount;
 
-  const delegation = createDelegation({
-    to: delegate,
-    from: delegator.address,
-    caveats: createCaveatBuilder(environment).addCaveat(
-      'specificActionERC20TransferBatch',
-      tokenAddress,
-      recipient,
-      amount,
-      firstTarget,
-      firstCalldata,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: delegate,
+    delegator: delegator.address,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(environment)
+      .addCaveat('specificActionERC20TransferBatch', {
+        tokenAddress,
+        recipient,
+        amount,
+        firstTarget,
+        firstCalldata,
+      })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -162,18 +167,22 @@ const runTest_expectFailure = async (
 ) => {
   const { environment } = aliceSmartAccount;
 
-  const delegation = createDelegation({
-    to: delegate,
-    from: delegator.address,
-    caveats: createCaveatBuilder(environment).addCaveat(
-      'specificActionERC20TransferBatch',
-      tokenAddress,
-      recipient,
-      amount,
-      firstTarget,
-      firstCalldata,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: delegate,
+    delegator: delegator.address,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(environment)
+      .addCaveat('specificActionERC20TransferBatch', {
+        tokenAddress,
+        recipient,
+        amount,
+        firstTarget,
+        firstCalldata,
+      })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,

--- a/packages/delegator-e2e/test/caveats/timestamp.test.ts
+++ b/packages/delegator-e2e/test/caveats/timestamp.test.ts
@@ -1,12 +1,13 @@
 import { beforeEach, test, expect } from 'vitest';
 import {
-  createCaveatBuilder,
   createExecution,
-  createDelegation,
+  Delegation,
   Implementation,
+  ROOT_AUTHORITY,
   toMetaMaskSmartAccount,
   type MetaMaskSmartAccount,
 } from '@metamask/delegation-toolkit';
+import { createCaveatBuilder } from '@metamask/delegation-toolkit/utils';
 import {
   encodeExecutionCalldatas,
   encodePermissionContexts,
@@ -153,15 +154,19 @@ const runTest_expectSuccess = async (
   const bobAddress = bobSmartAccount.address;
   const aliceAddress = aliceSmartAccount.address;
 
-  const delegation = createDelegation({
-    to: bobAddress,
-    from: aliceAddress,
-    caveats: createCaveatBuilder(aliceSmartAccount.environment).addCaveat(
-      'timestamp',
-      afterThreshold,
-      beforeThreshold,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: bobAddress,
+    delegator: aliceAddress,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(aliceSmartAccount.environment)
+      .addCaveat('timestamp', {
+        timestampAfterThreshold: afterThreshold,
+        timestampBeforeThreshold: beforeThreshold,
+      })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -232,15 +237,19 @@ const runTest_expectFailure = async (
   const bobAddress = bobSmartAccount.address;
   const aliceAddress = aliceSmartAccount.address;
 
-  const delegation = createDelegation({
-    to: bobAddress,
-    from: aliceAddress,
-    caveats: createCaveatBuilder(aliceSmartAccount.environment).addCaveat(
-      'timestamp',
-      afterThreshold,
-      beforeThreshold,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: bobAddress,
+    delegator: aliceAddress,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(aliceSmartAccount.environment)
+      .addCaveat('timestamp', {
+        timestampAfterThreshold: afterThreshold,
+        timestampBeforeThreshold: beforeThreshold,
+      })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,

--- a/packages/delegator-e2e/test/caveats/valueLte.test.ts
+++ b/packages/delegator-e2e/test/caveats/valueLte.test.ts
@@ -5,13 +5,14 @@ import {
   SINGLE_DEFAULT_MODE,
 } from '@metamask/delegation-toolkit/utils';
 import {
-  createCaveatBuilder,
-  createDelegation,
   createExecution,
+  Delegation,
   Implementation,
+  ROOT_AUTHORITY,
   toMetaMaskSmartAccount,
   type MetaMaskSmartAccount,
 } from '@metamask/delegation-toolkit';
+import { createCaveatBuilder } from '@metamask/delegation-toolkit/utils';
 
 import {
   fundAddress,
@@ -117,14 +118,16 @@ const submitUserOperationForTest = async (
   const bobAddress = bobSmartAccount.address;
   const aliceAddress = aliceSmartAccount.address;
 
-  const delegation = createDelegation({
-    to: bobAddress,
-    from: aliceAddress,
-    caveats: createCaveatBuilder(aliceSmartAccount.environment).addCaveat(
-      'valueLte',
-      maxValue,
-    ),
-  });
+  const delegation: Delegation = {
+    delegate: bobAddress,
+    delegator: aliceAddress,
+    authority: ROOT_AUTHORITY,
+    caveats: createCaveatBuilder(aliceSmartAccount.environment)
+      .addCaveat('valueLte', { maxValue })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,

--- a/packages/delegator-e2e/test/delegateAndRedeem.test.ts
+++ b/packages/delegator-e2e/test/delegateAndRedeem.test.ts
@@ -10,16 +10,17 @@ import {
 import { expectCodeAt, expectUserOperationToSucceed } from './utils/assertions';
 
 import {
-  createCaveatBuilder,
   createExecution,
-  createDelegation,
+  Delegation,
   Implementation,
+  ROOT_AUTHORITY,
   toMetaMaskSmartAccount,
   signDelegation,
   aggregateSignature,
   type MetaMaskSmartAccount,
   type PartialSignature,
 } from '@metamask/delegation-toolkit';
+import { createCaveatBuilder } from '@metamask/delegation-toolkit/utils';
 import {
   encodePermissionContexts,
   encodeExecutionCalldatas,
@@ -93,13 +94,17 @@ test('maincase: Bob increments the counter with a delegation from Alice', async 
 
   expect(countBefore, 'Expected initial count to be 0n').toEqual(0n);
 
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
+    authority: ROOT_AUTHORITY,
     caveats: createCaveatBuilder(aliceSmartAccount.environment)
-      .addCaveat('allowedTargets', [aliceCounterContractAddress])
-      .addCaveat('allowedMethods', ['increment()']),
-  });
+      .addCaveat('allowedTargets', { targets: [aliceCounterContractAddress] })
+      .addCaveat('allowedMethods', { selectors: ['increment()'] })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -197,13 +202,17 @@ test("Bob attempts to increment the counter with a delegation from Alice that do
   const countBefore = await counterContract.read.count();
   expect(countBefore, 'Expected initial count to be 0n').toEqual(0n);
 
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
+    authority: ROOT_AUTHORITY,
     caveats: createCaveatBuilder(aliceSmartAccount.environment)
-      .addCaveat('allowedTargets', [aliceCounterContractAddress])
-      .addCaveat('allowedMethods', ['notTheRightFunction()']),
-  });
+      .addCaveat('allowedTargets', { targets: [aliceCounterContractAddress] })
+      .addCaveat('allowedMethods', { selectors: ['notTheRightFunction()'] })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   const signedDelegation = {
     ...delegation,
@@ -275,13 +284,17 @@ test('Bob increments the counter with a delegation from a multisig account', asy
   const countBefore = await counterContract.read.count();
   expect(countBefore, 'Expected initial count to be 0n').toEqual(0n);
 
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: multisigSmartAccount.address,
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: multisigSmartAccount.address,
+    authority: ROOT_AUTHORITY,
     caveats: createCaveatBuilder(multisigSmartAccount.environment)
-      .addCaveat('allowedTargets', [counterContract.address])
-      .addCaveat('allowedMethods', ['increment()']),
-  });
+      .addCaveat('allowedTargets', { targets: [counterContract.address] })
+      .addCaveat('allowedMethods', { selectors: ['increment()'] })
+      .build(),
+    salt: '0x',
+    signature: '0x',
+  };
 
   // Get signatures from each signer
   const signatures: PartialSignature[] = await Promise.all(

--- a/packages/delegator-e2e/test/delegateAndRedeem.test.ts
+++ b/packages/delegator-e2e/test/delegateAndRedeem.test.ts
@@ -18,12 +18,12 @@ import {
   signDelegation,
   aggregateSignature,
   type MetaMaskSmartAccount,
+  type PartialSignature,
 } from '@metamask/delegation-toolkit';
 import {
   encodePermissionContexts,
   encodeExecutionCalldatas,
   SINGLE_DEFAULT_MODE,
-  type PartialSignature,
 } from '@metamask/delegation-toolkit/utils';
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 import {

--- a/packages/delegator-e2e/test/experimental/erc7710sendTransactionWithDelegation.test.ts
+++ b/packages/delegator-e2e/test/experimental/erc7710sendTransactionWithDelegation.test.ts
@@ -146,7 +146,7 @@ test('Bob redelegates to Carol, who redeems the delegation to call increment() o
     from: bob.address,
     parentDelegation: signedDelegation,
     caveats: createCaveatBuilder(aliceSmartAccount.environment, {
-      allowEmptyCaveats: true,
+      allowInsecureUnrestrictedDelegation: true,
     }),
   });
 

--- a/packages/delegator-e2e/test/experimental/erc7710sendUserOperationWithDelegation.test.ts
+++ b/packages/delegator-e2e/test/experimental/erc7710sendUserOperationWithDelegation.test.ts
@@ -65,9 +65,7 @@ beforeEach(async () => {
   const aliceCounter = await deployCounter(aliceSmartAccount.address);
   aliceCounterContractAddress = aliceCounter.address;
 
-  const caveats = createCaveatBuilder(aliceSmartAccount.environment, {
-    allowEmptyCaveats: true,
-  })
+  const caveats = createCaveatBuilder(aliceSmartAccount.environment)
     .addCaveat('allowedTargets', [aliceCounterContractAddress])
     .addCaveat('allowedMethods', ['increment()'])
     .addCaveat('valueLte', 0n);

--- a/packages/delegator-e2e/test/experimental/erc7710sendUserOperationWithDelegation.test.ts
+++ b/packages/delegator-e2e/test/experimental/erc7710sendUserOperationWithDelegation.test.ts
@@ -15,10 +15,10 @@ import {
   Implementation,
   toMetaMaskSmartAccount,
   type MetaMaskSmartAccount,
-  createCaveatBuilder,
-  createDelegation,
+  ROOT_AUTHORITY,
   type Delegation,
 } from '@metamask/delegation-toolkit';
+import { createCaveatBuilder } from '@metamask/delegation-toolkit/utils';
 import { erc7710BundlerActions } from '@metamask/delegation-toolkit/experimental';
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 import {
@@ -66,15 +66,18 @@ beforeEach(async () => {
   aliceCounterContractAddress = aliceCounter.address;
 
   const caveats = createCaveatBuilder(aliceSmartAccount.environment)
-    .addCaveat('allowedTargets', [aliceCounterContractAddress])
-    .addCaveat('allowedMethods', ['increment()'])
-    .addCaveat('valueLte', 0n);
+    .addCaveat('allowedTargets', { targets: [aliceCounterContractAddress] })
+    .addCaveat('allowedMethods', { selectors: ['increment()'] })
+    .addCaveat('valueLte', { maxValue: 0n });
 
-  const delegation = createDelegation({
-    to: bobSmartAccount.address,
-    from: aliceSmartAccount.address,
-    caveats,
-  });
+  const delegation: Delegation = {
+    delegate: bobSmartAccount.address,
+    delegator: aliceSmartAccount.address,
+    caveats: caveats.build(),
+    salt: '0x',
+    signature: '0x',
+    authority: ROOT_AUTHORITY,
+  };
 
   signedDelegation = {
     ...delegation,


### PR DESCRIPTION
## 📝 Description

This changes how a developer interacts with CaveatBuilders in order to reduce the risk of signing delegations with insufficient attenuation.

## 🔄 What Changed?

List the specific changes made:
- rename `allowEmptyCaveats` to `allowInsecureUnrestrictedDelegation`
- require `allowInsecureUnrestrictedDelegation` not just when creating a CaveatBuilder, but also when creating, and when signing a Delegation
- `createCaveatBuilder` moved from root export to `/utils`
- All CaveatBuilders now accept config object, rather than positional arguments
- Standardised `callData` to `calldata` in the ExactCalldata terms builder
- Introduces UnitOfAuthority CaveatBuilder factories as the primary interface to creating caveats

## 🚀 Why?

Even with the `allowEmptyCaveats` flag, there is a high risk of developers creating delegations with less attenuation than they expect. Because of this, we have made two general changes:

1. It's not much harder to accidentally create empty caveat collections, because the configuration flag is more likely to stand out as a problem, because of it's name. It is now required with creating and signing delegations, which will capture cases when the `CaveatBuidler` interface is not used, and generally introduces more friction to high risk full authority delegations.

2. Instead of a developer starting with Full Authority, and attenuating that through addition of Caveats, a developer now starts with a "Unit of Authority", which constrains the delegation to interact with a native token, erc20, erc721, ownership, etc, with specific constraints out of the box. The developer may then further attenuate the permission.

## 🧪 How to Test?

There is reasonable amount of coverage of this new behaviour. A test dapp could be created that creates delegations using these new UnitOfAuthority factories, such as:

```
// create a caveat builder allowing transfer of an amount of a specified ERC20 token
const caveatBuilder = createErc20CaveatBuilder({
  environment,
  tokenAddress,
  maxAmount
});

// further attenuate with limitedCalls, meaning the entire maxAmount must be spent in a single transaction
caveatBuilder.addCaveat("limitedCalls" , { limit: 1 });
```

- [x] Automated tests added/updated
- [x] All existing tests pass

## ⚠️ Breaking Changes

List any breaking changes:

- [ ] No breaking changes
- [x] Breaking changes (describe below):

- CaveatBuilder now accepts config object for _all_ caveat types
- CaveatBuilder may no longer be imported from the root export, but now from the `/utils` export (we should encourage use of the UnitOfAuthority caveat builder factories.
- @metamask/delegation-core terms builder now accepts `calldata` parameter, rather than `callData` (but this is unreleased, so maybe doesn't count).

## 📋 Checklist

Check off completed items:

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] Changelog updated (if needed)
- [ ] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:
