### PR TITLE
chore: remove regex stripping trailing slash from configured url

### DIFF
--- a/packages/delegation-toolkit/src/experimental/delegationStorage.ts
+++ b/packages/delegation-toolkit/src/experimental/delegationStorage.ts
@@ -53,13 +53,16 @@ export class DelegationStorageClient {
   #apiUrl: string;
 
   constructor(config: DelegationStorageConfig) {
-    let apiUrl = config.environment.apiUrl.replace(/\/+$/u, ''); // Remove trailing slashes
-    if (!apiUrl.endsWith(this.#apiVersionPrefix)) {
-      apiUrl = `${apiUrl}/${this.#apiVersionPrefix}`;
+    const { apiUrl } = config.environment;
+
+    if (apiUrl.endsWith(this.#apiVersionPrefix)) {
+      this.#apiUrl = apiUrl;
+    } else {
+      const separator = apiUrl.endsWith('/') ? '' : '/';
+      this.#apiUrl = `${apiUrl}${separator}${this.#apiVersionPrefix}`;
     }
     this.#fetcher = this.#initializeFetcher(config);
     this.#config = config;
-    this.#apiUrl = apiUrl;
   }
 
   /**

--- a/packages/delegation-toolkit/test/experimental/delegationStorage.test.ts
+++ b/packages/delegation-toolkit/test/experimental/delegationStorage.test.ts
@@ -1,4 +1,5 @@
 import { stub } from 'sinon';
+import { zeroAddress } from 'viem';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
@@ -55,6 +56,30 @@ describe('DelegationStorageClient', () => {
       });
 
       expect(delegationStore).toBeInstanceOf(DelegationStorageClient);
+    });
+
+    it('accepts an apiUrl with a trailing slash', async () => {
+      mockFetch.resolves({
+        json: async () => Promise.resolve([]),
+      });
+
+      const delegationStore = new DelegationStorageClient({
+        ...mockConfig,
+        environment: {
+          apiUrl: `${mockApiUrl}/`,
+        },
+        fetcher: mockFetch,
+      });
+
+      await delegationStore.fetchDelegations(zeroAddress);
+
+      const calledUrl = mockFetch.getCall(0).args[0];
+
+      const expectedUrlPrefix = `${mockApiUrl}/api/v0/delegation`;
+
+      expect(calledUrl.slice(0, expectedUrlPrefix.length)).toStrictEqual(
+        expectedUrlPrefix,
+      );
     });
   });
 


### PR DESCRIPTION
## 📝 Description

When configuring the delegation storage client, a regex is used to strip trailing slashes from the provided URL. This change removes that and replaces it with a bounded mechanism.

## 🔄 What Changed?

Regex stripping trailing slashes was replaced with mechanism that inserts a separating slash if one doesn't exist on the provided URL.

## 🚀 Why?

Resolves https://github.com/MetaMask/delegation-toolkit/security/code-scanning/2 polynomial regex expression.

## 🧪 How to Test?

No changes in behaviour.

Configuring the delegation storage url with a trailing '/' should continue to work.
"accepts an apiUrl with a trailing slash" added to `packages/delegation-toolkit/test/experimental/delegationStorage.test.ts` validates this case

## ⚠️ Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Tests added/updated
- [x] Changelog updated (if needed)
- [x] All CI checks pass

