### PR TITLE
fix: `sendTransactionWithDelegation` fails for value transfers

### DIFF
--- a/packages/delegation-toolkit/src/experimental/erc7710RedeemDelegationAction.ts
+++ b/packages/delegation-toolkit/src/experimental/erc7710RedeemDelegationAction.ts
@@ -79,8 +79,15 @@ export async function sendTransactionWithDelegationAction<
     ],
   });
 
+  const {
+    value: _value,
+    permissionsContext: _permissionsContext,
+    delegationManager: _delegationManager,
+    ...rest
+  } = args;
+
   const hash = await client.sendTransaction({
-    ...args,
+    ...rest,
     to: args.delegationManager,
     data: calldata,
   } as unknown as SendTransactionParameters);

--- a/packages/delegation-toolkit/test/experimental/erc7710RedeemDelegationAction.test.ts
+++ b/packages/delegation-toolkit/test/experimental/erc7710RedeemDelegationAction.test.ts
@@ -318,15 +318,20 @@ describe('erc7710RedeemDelegationAction', () => {
         ],
       });
 
+      const { delegationManager } = args;
+
       const expectedArgs = {
-        ...args,
-        to: args.delegationManager,
+        account,
+        chain,
+        to: delegationManager,
+        // value is not passed to sendTransaction
         data: redeemDelegationCallData,
+        // permissionsContext and delegationManager are not passed to sendTransaction
       };
 
-      expect(sendTransaction.calledOnceWithExactly(expectedArgs)).to.equal(
-        true,
-      );
+      expect(sendTransaction.calledOnce).to.equal(true);
+
+      expect(sendTransaction.firstCall.args[0]).to.deep.equal(expectedArgs);
     });
 
     it('should throw an error when `to` is not provided', async () => {
@@ -343,6 +348,34 @@ describe('erc7710RedeemDelegationAction', () => {
         }),
       ).rejects.toThrow(
         '`to` is required. `sendTransactionWithDelegation` cannot be used to deploy contracts.',
+      );
+    });
+
+    it('should not encode the specified `value`, `permissionsContext` and `delegationManager` into the resulting transaction', async () => {
+      const extendedWalletClient = walletClient.extend(erc7710WalletActions());
+
+      const sendTransaction = stub(walletClient, 'sendTransaction');
+
+      const args: SendTransactionWithDelegationParameters = {
+        account,
+        chain,
+        to: randomAddress(),
+        value: 100n,
+        data: randomBytes(128),
+        permissionsContext: randomBytes(128),
+        delegationManager: randomAddress(),
+      };
+
+      await extendedWalletClient.sendTransactionWithDelegation(args);
+
+      expect(sendTransaction.calledOnce).to.equal(true);
+      const sendTransactionArgs = sendTransaction.firstCall.args[0];
+      expect(sendTransactionArgs.value).to.equal(undefined);
+      expect((sendTransactionArgs as any).permissionsContext).to.equal(
+        undefined,
+      );
+      expect((sendTransactionArgs as any).delegationManager).to.equal(
+        undefined,
       );
     });
   });

--- a/packages/delegator-e2e/test/experimental/erc7710sendTransactionWithDelegation.test.ts
+++ b/packages/delegator-e2e/test/experimental/erc7710sendTransactionWithDelegation.test.ts
@@ -5,6 +5,7 @@ import {
   deploySmartAccount,
   publicClient,
   fundAddress,
+  randomAddress,
 } from '../utils/helpers';
 import { chain } from '../../src/config';
 
@@ -229,4 +230,55 @@ test('Bob attempts to call the increment function directly', async () => {
   const countAfter = await counterContract.read.count();
 
   expect(countAfter).toEqual(0n);
+});
+
+test('Bob sends a native value transaction with delegation', async () => {
+  await deploySmartAccount(aliceSmartAccount);
+
+  const allowance = 100n;
+  const recipient = randomAddress();
+
+  const { DelegationManager: delegationManager } =
+    aliceSmartAccount.environment;
+
+  const caveats = createCaveatBuilder(aliceSmartAccount.environment).addCaveat(
+    'nativeTokenTransferAmount',
+    allowance,
+  );
+
+  const delegation = createDelegation({
+    to: bob.address,
+    from: aliceSmartAccount.address,
+    caveats,
+  });
+
+  const signedDelegation = {
+    ...delegation,
+    signature: await aliceSmartAccount.signDelegation({ delegation }),
+  };
+
+  const permissionsContext = encodeDelegations([signedDelegation]);
+
+  const bobWalletClient = createWalletClient({
+    account: bob,
+    transport,
+    chain,
+  }).extend(erc7710WalletActions());
+
+  await fundAddress(aliceSmartAccount.address, allowance);
+
+  const transactionHash = await bobWalletClient.sendTransactionWithDelegation({
+    account: bob,
+    chain,
+    to: recipient,
+    value: allowance,
+    permissionsContext,
+    delegationManager,
+  });
+
+  await publicClient.waitForTransactionReceipt({ hash: transactionHash });
+
+  const balance = await publicClient.getBalance({ address: recipient });
+
+  expect(balance).toEqual(allowance);
 });


### PR DESCRIPTION
## 📝 Description

When `value` is included in the arguments to `sendTransactionWithDelegation`, this is encoded into the calldata. This change fixes a bug where this was left in the arguments passed to `sendTransaction` resulting in value being included in the call to `redeemDelegation`, and a failing transaction.

## 🔄 What Changed?

- `value` is no longer included in the args passed to `sendTransaction`
- unit test is added to ensure that the `value` is not passed through
- integration test added to ensure that the transaction is successful

## 🧪 How to Test?

The integration test outlines the end-behaviour being tested.
## 🔗 Related Issues

Link to related issues:
Closes #28 
