### PR TITLE
Use Map to maintain delegator environment overrides

### DIFF
--- a/packages/delegation-toolkit/src/delegatorEnvironment.ts
+++ b/packages/delegation-toolkit/src/delegatorEnvironment.ts
@@ -81,11 +81,9 @@ export function getDeleGatorEnvironment(
 ): DeleGatorEnvironment {
   const overrideKey = getContractOverrideKey(chainId, version);
 
-  if (contractOverrideMap.has(overrideKey)) {
-    const overridenContracts = contractOverrideMap.get(overrideKey);
-    if (overridenContracts) {
-      return overridenContracts;
-    }
+  const overriddenContracts = contractOverrideMap.get(overrideKey);
+  if (overriddenContracts) {
+    return overriddenContracts;
   }
 
   const contracts = DELEGATOR_CONTRACTS[version]?.[chainId];


### PR DESCRIPTION
## 📝 Description

Previously the delegation overrides were maintained on a simple object, mapping version, and chainId to the DeleGatorEnvironment. With this change, a `Map<string, DeleGatorEnvironment>` is used to maintain this information.

## 🔄 What Changed?

When overriding a delegator deployment, a key is generated from the version and chainId, which is used in the key of a `Map` to `set` the value to the overiden environment. When fetching the same util is used to generate the key, if the key exists in the map, then the value is returned.

## 🚀 Why?

This resolves the following vulnerability, where malicious input could potentially pollute the global object prototype https://github.com/MetaMask/delegation-toolkit/security/code-scanning/1

## 🧪 How to Test?

No functional changes - overriding deployed environments is covered in unit tests.

## ⚠️ Breaking Changes

List any breaking changes:

- [x] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Tests added/updated
- [x] Changelog updated (if needed)
- [x] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes # https://github.com/MetaMask/delegation-toolkit/security/code-scanning/1
