### PR TITLE
make startTime in native-token-stream optional

### DIFF
--- a/packages/delegation-toolkit/src/experimental/erc7715GrantPermissionsAction.ts
+++ b/packages/delegation-toolkit/src/experimental/erc7715GrantPermissionsAction.ts
@@ -28,7 +28,7 @@ export type NativeTokenStreamPermission = Permission & {
   data: {
     initialAmount?: bigint;
     amountPerSecond: bigint;
-    startTime: number;
+    startTime?: number;
     maxAmount?: number;
     justification: string;
   };
@@ -392,10 +392,6 @@ function formatNativeTokenStreamPermission(
     permission.data.justification,
     'Invalid parameters: justification is required',
   );
-  assertIsDefined(
-    permission.data.startTime,
-    'Invalid parameters: startTime is required',
-  );
 
   const isInitialAmountSpecified =
     permission.data.initialAmount !== undefined &&
@@ -405,12 +401,19 @@ function formatNativeTokenStreamPermission(
     permission.data.maxAmount !== undefined &&
     permission.data.maxAmount !== null;
 
+  const isStartTimeSpecified =
+    permission.data.startTime !== undefined &&
+    permission.data.startTime !== null;
+
   const optionalFields = {
     ...(isInitialAmountSpecified && {
       initialAmount: toHexOrThrow(permission.data.initialAmount),
     }),
     ...(isMaxAmountSpecified && {
       maxAmount: toHexOrThrow(permission.data.maxAmount),
+    }),
+    ...(isStartTimeSpecified && {
+      startTime: Number(permission.data.startTime),
     }),
   };
 
@@ -421,7 +424,6 @@ function formatNativeTokenStreamPermission(
         permission.data.amountPerSecond,
         'Invalid parameters: amountPerSecond is required',
       ),
-      startTime: Number(permission.data.startTime),
       justification: permission.data.justification,
       ...optionalFields,
     },

--- a/packages/delegation-toolkit/test/experimental/erc7715GrantPermissionsAction.test.ts
+++ b/packages/delegation-toolkit/test/experimental/erc7715GrantPermissionsAction.test.ts
@@ -137,31 +137,6 @@ describe('erc7715GrantPermissionsAction', () => {
       ).rejects.toThrow('Invalid parameters: amountPerSecond is required');
     });
 
-    it('should throw an error when startTime is undefined', async () => {
-      const parameters = [
-        {
-          chainId: 31337,
-          address: bob.address,
-          expiry: 1234567890,
-          permission: {
-            type: 'native-token-stream',
-            data: {
-              amountPerSecond: '0x1',
-              maxAmount: '0x2',
-              startTime: undefined,
-              justification: 'Test justification',
-            },
-          },
-          isAdjustmentAllowed: false,
-          signer: { type: 'account', data: { address: alice.address } },
-        },
-      ];
-
-      await expect(
-        erc7715GrantPermissionsAction(mockClient, parameters),
-      ).rejects.toThrow('Invalid parameters: startTime is required');
-    });
-
     it('should throw an error when justification is undefined', async () => {
       const parameters = [
         {


### PR DESCRIPTION
## 📝 Description

Make `startTime` optional. In case its not defined permission snap will set `startTime` as `Date.now()` to ensure the current time for user.

## 🔄 What Changed?

List the specific changes made:
- `startTime` set to optional.

## 🚀 Why?

Explain the motivation behind these changes:
- Snap will set `startTime` in case its not set.

## 🧪 How to Test?

Describe how to test these changes:

- [x] Manual testing steps:
 1. Use experimental permission action with `startTime` not set.
- [x] Automated tests added/updated
- [x] All existing tests pass

## ⚠️ Breaking Changes

List any breaking changes:

- [x] No breaking changes

## 📋 Checklist

Check off completed items:

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Tests added/updated
- [x] Changelog updated (if needed)
- [x] All CI checks pass

## 🔗 Related Issues

Link to related issues:
https://github.com/MetaMask/snap-7715-permissions/pull/110


## 📚 Additional Notes

/
