### PR TITLE
Fix incorrect service availability log

### DIFF
--- a/packages/delegator-e2e/src/await-dependencies.ts
+++ b/packages/delegator-e2e/src/await-dependencies.ts
@@ -39,7 +39,9 @@ const waitFor = async (name: string, url: string) => {
       .catch((e) => (isAvailable = (e as Error).name !== 'HttpRequestError'));
   } while (!isAvailable && !hasTimedOut);
 
-  console.log(`${name} is available`);
+  if (isAvailable) {
+    console.log(`${name} is available`);
+  }
 };
 
 const deployEnvironment = async () => {


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug in the `waitFor` function where it would incorrectly log that a service is available even when it timed out.

## 🔄 What Changed?

List the specific changes made:
- The `console.log(`${name} is available`)` statement in the `waitFor` function is now conditional.
- The log message will only be printed if `isAvailable` is `true` upon exiting the loop.

## 🚀 Why?

Explain the motivation behind these changes:
- To prevent misleading log output when the `waitFor` function times out.
- To ensure that the "service is available" message accurately reflects the service's status.

## 🧪 How to Test?

Describe how to test these changes:

- [ ] Manual testing steps:
 1. Run the e2e tests (e.g., `npm run test:e2e`).
 2. Observe the console output for the `waitFor` function.
 3. Verify that if a service times out, it does not print the "service is available" message.
 4. Verify that if a service successfully becomes available, it *does* print the "service is available" message.
- [ ] Automated tests added/updated
- [ ] All existing tests pass

## ⚠️ Breaking Changes

List any breaking changes:

- [ ] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] Changelog updated (if needed)
- [ ] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

This change ensures that the logging behavior of the `waitFor` function is consistent with its actual outcome, providing clearer feedback during e2e test runs.

---

[Open in Web](https://www.cursor.com/agents?id=bc-1136d859-bc7f-46dd-93b0-51cd58d7c863) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-1136d859-bc7f-46dd-93b0-51cd58d7c863)