### PR TITLE
Accept delegation object and move client export

### DIFF
--- a/packages/delegation-toolkit/src/actions/getCaveatAvailableAmount.ts
+++ b/packages/delegation-toolkit/src/actions/getCaveatAvailableAmount.ts
@@ -9,37 +9,9 @@ import { hashDelegation } from '../delegation';
 import type { DeleGatorEnvironment, Delegation } from '../types';
 
 /**
- * Parameters for ERC20 period transfer enforcer.
+ * Parameters for all caveat enforcer actions.
  */
-export type ERC20PeriodTransferParams = {
-  delegation: Delegation;
-};
-
-/**
- * Parameters for ERC20 streaming enforcer.
- */
-export type ERC20StreamingParams = {
-  delegation: Delegation;
-};
-
-/**
- * Parameters for MultiTokenPeriodEnforcer.
- */
-export type MultiTokenPeriodParams = {
-  delegation: Delegation;
-};
-
-/**
- * Parameters for native token period transfer enforcer.
- */
-export type NativeTokenPeriodTransferParams = {
-  delegation: Delegation;
-};
-
-/**
- * Parameters for native token streaming enforcer.
- */
-export type NativeTokenStreamingParams = {
+export type CaveatEnforcerParams = {
   delegation: Delegation;
 };
 
@@ -137,7 +109,7 @@ function getEnforcerAddress(
 export async function getErc20PeriodTransferEnforcerAvailableAmount(
   client: PublicClient,
   environment: DeleGatorEnvironment,
-  params: ERC20PeriodTransferParams,
+  params: CaveatEnforcerParams,
 ): Promise<PeriodTransferResult> {
   const delegationManager = getDelegationManager(environment);
   const enforcerAddress = getEnforcerAddress(
@@ -168,7 +140,7 @@ export async function getErc20PeriodTransferEnforcerAvailableAmount(
 export async function getErc20StreamingEnforcerAvailableAmount(
   client: PublicClient,
   environment: DeleGatorEnvironment,
-  params: ERC20StreamingParams,
+  params: CaveatEnforcerParams,
 ): Promise<StreamingResult> {
   const delegationManager = getDelegationManager(environment);
   const enforcerAddress = getEnforcerAddress(
@@ -199,7 +171,7 @@ export async function getErc20StreamingEnforcerAvailableAmount(
 export async function getMultiTokenPeriodEnforcerAvailableAmount(
   client: PublicClient,
   environment: DeleGatorEnvironment,
-  params: MultiTokenPeriodParams,
+  params: CaveatEnforcerParams,
 ): Promise<PeriodTransferResult> {
   const delegationManager = getDelegationManager(environment);
   const enforcerAddress = getEnforcerAddress(
@@ -231,7 +203,7 @@ export async function getMultiTokenPeriodEnforcerAvailableAmount(
 export async function getNativeTokenPeriodTransferEnforcerAvailableAmount(
   client: PublicClient,
   environment: DeleGatorEnvironment,
-  params: NativeTokenPeriodTransferParams,
+  params: CaveatEnforcerParams,
 ): Promise<PeriodTransferResult> {
   const delegationManager = getDelegationManager(environment);
   const enforcerAddress = getEnforcerAddress(
@@ -262,7 +234,7 @@ export async function getNativeTokenPeriodTransferEnforcerAvailableAmount(
 export async function getNativeTokenStreamingEnforcerAvailableAmount(
   client: PublicClient,
   environment: DeleGatorEnvironment,
-  params: NativeTokenStreamingParams,
+  params: CaveatEnforcerParams,
 ): Promise<StreamingResult> {
   const delegationManager = getDelegationManager(environment);
   const enforcerAddress = getEnforcerAddress(
@@ -299,7 +271,7 @@ export const caveatEnforcerActions =
      * @returns Promise resolving to the period transfer result.
      */
     getErc20PeriodTransferEnforcerAvailableAmount: async (
-      params: ERC20PeriodTransferParams,
+      params: CaveatEnforcerParams,
     ): Promise<PeriodTransferResult> => {
       return getErc20PeriodTransferEnforcerAvailableAmount(
         client,
@@ -315,7 +287,7 @@ export const caveatEnforcerActions =
      * @returns Promise resolving to the streaming result.
      */
     getErc20StreamingEnforcerAvailableAmount: async (
-      params: ERC20StreamingParams,
+      params: CaveatEnforcerParams,
     ): Promise<StreamingResult> => {
       return getErc20StreamingEnforcerAvailableAmount(
         client,
@@ -331,7 +303,7 @@ export const caveatEnforcerActions =
      * @returns Promise resolving to the period transfer result.
      */
     getMultiTokenPeriodEnforcerAvailableAmount: async (
-      params: MultiTokenPeriodParams,
+      params: CaveatEnforcerParams,
     ): Promise<PeriodTransferResult> => {
       return getMultiTokenPeriodEnforcerAvailableAmount(
         client,
@@ -347,7 +319,7 @@ export const caveatEnforcerActions =
      * @returns Promise resolving to the period transfer result.
      */
     getNativeTokenPeriodTransferEnforcerAvailableAmount: async (
-      params: NativeTokenPeriodTransferParams,
+      params: CaveatEnforcerParams,
     ): Promise<PeriodTransferResult> => {
       return getNativeTokenPeriodTransferEnforcerAvailableAmount(
         client,
@@ -363,7 +335,7 @@ export const caveatEnforcerActions =
      * @returns Promise resolving to the streaming result.
      */
     getNativeTokenStreamingEnforcerAvailableAmount: async (
-      params: NativeTokenStreamingParams,
+      params: CaveatEnforcerParams,
     ): Promise<StreamingResult> => {
       return getNativeTokenStreamingEnforcerAvailableAmount(
         client,

--- a/packages/delegation-toolkit/src/actions/getCaveatAvailableAmount.ts
+++ b/packages/delegation-toolkit/src/actions/getCaveatAvailableAmount.ts
@@ -59,25 +59,7 @@ export type StreamingResult = {
   availableAmount: bigint;
 };
 
-/**
- * Error thrown when no matching caveat is found
- */
-export class NoMatchingCaveatError extends Error {
-  constructor(enforcerName: string) {
-    super(`No caveat found with enforcer matching ${enforcerName}`);
-    this.name = 'NoMatchingCaveatError';
-  }
-}
 
-/**
- * Error thrown when multiple matching caveats are found
- */
-export class MultipleMatchingCaveatsError extends Error {
-  constructor(enforcerName: string) {
-    super(`Multiple caveats found with enforcer matching ${enforcerName}`);
-    this.name = 'MultipleMatchingCaveatsError';
-  }
-}
 
 
 
@@ -86,8 +68,8 @@ export class MultipleMatchingCaveatsError extends Error {
  * @param delegation - The delegation to search
  * @param enforcerAddress - The enforcer address to match
  * @returns The matching caveat
- * @throws NoMatchingCaveatError if no matching caveat is found
- * @throws MultipleMatchingCaveatsError if multiple matching caveats are found
+ * @throws Error if no matching caveat is found
+ * @throws Error if multiple matching caveats are found
  */
 function findMatchingCaveat(
   delegation: Delegation,
@@ -98,11 +80,11 @@ function findMatchingCaveat(
   );
 
   if (matchingCaveats.length === 0) {
-    throw new NoMatchingCaveatError(enforcerAddress);
+    throw new Error(`No caveat found with enforcer matching ${enforcerAddress}`);
   }
 
   if (matchingCaveats.length > 1) {
-    throw new MultipleMatchingCaveatsError(enforcerAddress);
+    throw new Error(`Multiple caveats found with enforcer matching ${enforcerAddress}`);
   }
 
   return {

--- a/packages/delegation-toolkit/src/actions/index.ts
+++ b/packages/delegation-toolkit/src/actions/index.ts
@@ -10,12 +10,6 @@ export {
   getMultiTokenPeriodEnforcerAvailableAmount,
   getNativeTokenPeriodTransferEnforcerAvailableAmount,
   getNativeTokenStreamingEnforcerAvailableAmount,
-  // New delegation-based action functions
-  getErc20PeriodTransferEnforcerAvailableAmountFromDelegation,
-  getErc20StreamingEnforcerAvailableAmountFromDelegation,
-  getMultiTokenPeriodEnforcerAvailableAmountFromDelegation,
-  getNativeTokenPeriodTransferEnforcerAvailableAmountFromDelegation,
-  getNativeTokenStreamingEnforcerAvailableAmountFromDelegation,
   // Client extension exports
   createCaveatEnforcerClient,
   caveatEnforcerActions,
@@ -26,12 +20,6 @@ export {
   type MultiTokenPeriodParams,
   type NativeTokenPeriodTransferParams,
   type NativeTokenStreamingParams,
-  // New delegation-based parameter types
-  type ERC20PeriodTransferDelegationParams,
-  type ERC20StreamingDelegationParams,
-  type MultiTokenPeriodDelegationParams,
-  type NativeTokenPeriodTransferDelegationParams,
-  type NativeTokenStreamingDelegationParams,
   // Result types
   type PeriodTransferResult,
   type StreamingResult,

--- a/packages/delegation-toolkit/src/actions/index.ts
+++ b/packages/delegation-toolkit/src/actions/index.ts
@@ -10,6 +10,12 @@ export {
   getMultiTokenPeriodEnforcerAvailableAmount,
   getNativeTokenPeriodTransferEnforcerAvailableAmount,
   getNativeTokenStreamingEnforcerAvailableAmount,
+  // New delegation-based action functions
+  getErc20PeriodTransferEnforcerAvailableAmountFromDelegation,
+  getErc20StreamingEnforcerAvailableAmountFromDelegation,
+  getMultiTokenPeriodEnforcerAvailableAmountFromDelegation,
+  getNativeTokenPeriodTransferEnforcerAvailableAmountFromDelegation,
+  getNativeTokenStreamingEnforcerAvailableAmountFromDelegation,
   // Client extension exports
   createCaveatEnforcerClient,
   caveatEnforcerActions,
@@ -20,9 +26,18 @@ export {
   type MultiTokenPeriodParams,
   type NativeTokenPeriodTransferParams,
   type NativeTokenStreamingParams,
+  // New delegation-based parameter types
+  type ERC20PeriodTransferDelegationParams,
+  type ERC20StreamingDelegationParams,
+  type MultiTokenPeriodDelegationParams,
+  type NativeTokenPeriodTransferDelegationParams,
+  type NativeTokenStreamingDelegationParams,
   // Result types
   type PeriodTransferResult,
   type StreamingResult,
+  // Error types
+  type NoMatchingCaveatError,
+  type MultipleMatchingCaveatsError,
 } from './getCaveatAvailableAmount';
 
 export { isValid7702Implementation } from './isValid7702Implementation';

--- a/packages/delegation-toolkit/src/actions/index.ts
+++ b/packages/delegation-toolkit/src/actions/index.ts
@@ -23,9 +23,7 @@ export {
   // Result types
   type PeriodTransferResult,
   type StreamingResult,
-  // Error types
-  type NoMatchingCaveatError,
-  type MultipleMatchingCaveatsError,
+
 } from './getCaveatAvailableAmount';
 
 export { isValid7702Implementation } from './isValid7702Implementation';

--- a/packages/delegation-toolkit/src/actions/index.ts
+++ b/packages/delegation-toolkit/src/actions/index.ts
@@ -15,11 +15,7 @@ export {
   caveatEnforcerActions,
   type CaveatEnforcerClient,
   // Parameter types
-  type ERC20PeriodTransferParams,
-  type ERC20StreamingParams,
-  type MultiTokenPeriodParams,
-  type NativeTokenPeriodTransferParams,
-  type NativeTokenStreamingParams,
+  type CaveatEnforcerParams,
   // Result types
   type PeriodTransferResult,
   type StreamingResult,

--- a/packages/delegation-toolkit/src/index.ts
+++ b/packages/delegation-toolkit/src/index.ts
@@ -61,3 +61,9 @@ export { redeemDelegations } from './write';
 export * as contracts from './contracts';
 
 export * as actions from './actions';
+
+// Export the caveat enforcer client
+export {
+  createCaveatEnforcerClient,
+  type CaveatEnforcerClient,
+} from './actions';

--- a/packages/delegation-toolkit/test/actions/caveatEnforcerClient.test.ts
+++ b/packages/delegation-toolkit/test/actions/caveatEnforcerClient.test.ts
@@ -90,57 +90,7 @@ describe('CaveatEnforcerClient', () => {
       });
     });
 
-    it('should use custom delegation manager when provided', async () => {
-      const customDelegationManager = '0x9999999999999999999999999999999999999999';
-      const mockResult = {
-        availableAmount: 1000n,
-        isNewPeriod: true,
-        currentPeriod: 1n,
-      };
 
-      const { read } = await import('../../src/DelegationFramework/MultiTokenPeriodEnforcer/methods/getAvailableAmount');
-      vi.mocked(read).mockResolvedValue(mockResult);
-
-      await client.getMultiTokenPeriodEnforcerAvailableAmount({
-        delegation,
-        delegationManager: customDelegationManager,
-      });
-
-      expect(read).toHaveBeenCalledWith({
-        client: expect.any(Object),
-        contractAddress: environment.caveatEnforcers.MultiTokenPeriodEnforcer,
-        delegationHash: hashDelegation(delegation),
-        delegationManager: customDelegationManager,
-        terms: delegation.caveats[0].terms,
-        args: delegation.caveats[0].args,
-      });
-    });
-
-    it('should use custom enforcer address when provided', async () => {
-      const customEnforcerAddress = '0x9999999999999999999999999999999999999999';
-      const mockResult = {
-        availableAmount: 1000n,
-        isNewPeriod: true,
-        currentPeriod: 1n,
-      };
-
-      const { read } = await import('../../src/DelegationFramework/MultiTokenPeriodEnforcer/methods/getAvailableAmount');
-      vi.mocked(read).mockResolvedValue(mockResult);
-
-      await client.getMultiTokenPeriodEnforcerAvailableAmount({
-        delegation,
-        enforcerAddress: customEnforcerAddress,
-      });
-
-      expect(read).toHaveBeenCalledWith({
-        client: expect.any(Object),
-        contractAddress: customEnforcerAddress,
-        delegationHash: hashDelegation(delegation),
-        delegationManager: environment.DelegationManager,
-        terms: delegation.caveats[0].terms,
-        args: delegation.caveats[0].args,
-      });
-    });
   });
 
   describe('getErc20PeriodTransferEnforcerAvailableAmount with delegation', () => {
@@ -180,34 +130,7 @@ describe('CaveatEnforcerClient', () => {
     });
   });
 
-  describe('Legacy methods still work', () => {
-    it('should support legacy getMultiTokenPeriodEnforcerAvailableAmount method', async () => {
-      const mockResult = {
-        availableAmount: 1000n,
-        isNewPeriod: true,
-        currentPeriod: 1n,
-      };
 
-      const { read } = await import('../../src/DelegationFramework/MultiTokenPeriodEnforcer/methods/getAvailableAmount');
-      vi.mocked(read).mockResolvedValue(mockResult);
-
-      const result = await client.getMultiTokenPeriodEnforcerAvailableAmount({
-        delegationHash: hashDelegation(delegation),
-        terms: delegation.caveats[0].terms,
-        args: delegation.caveats[0].args,
-      });
-
-      expect(result).toEqual(mockResult);
-      expect(read).toHaveBeenCalledWith({
-        client: expect.any(Object),
-        contractAddress: environment.caveatEnforcers.MultiTokenPeriodEnforcer,
-        delegationHash: hashDelegation(delegation),
-        delegationManager: environment.DelegationManager,
-        terms: delegation.caveats[0].terms,
-        args: delegation.caveats[0].args,
-      });
-    });
-  });
 
   describe('Client type', () => {
     it('should have all expected methods', () => {

--- a/packages/delegation-toolkit/test/actions/caveatEnforcerClient.test.ts
+++ b/packages/delegation-toolkit/test/actions/caveatEnforcerClient.test.ts
@@ -64,7 +64,7 @@ describe('CaveatEnforcerClient', () => {
     };
   });
 
-  describe('getMultiTokenPeriodEnforcerAvailableAmountFromDelegation', () => {
+  describe('getMultiTokenPeriodEnforcerAvailableAmount with delegation', () => {
     it('should successfully get available amount using client', async () => {
       const mockResult = {
         availableAmount: 1000n,
@@ -75,7 +75,7 @@ describe('CaveatEnforcerClient', () => {
       const { read } = await import('../../src/DelegationFramework/MultiTokenPeriodEnforcer/methods/getAvailableAmount');
       vi.mocked(read).mockResolvedValue(mockResult);
 
-      const result = await client.getMultiTokenPeriodEnforcerAvailableAmountFromDelegation({
+      const result = await client.getMultiTokenPeriodEnforcerAvailableAmount({
         delegation,
       });
 
@@ -101,7 +101,7 @@ describe('CaveatEnforcerClient', () => {
       const { read } = await import('../../src/DelegationFramework/MultiTokenPeriodEnforcer/methods/getAvailableAmount');
       vi.mocked(read).mockResolvedValue(mockResult);
 
-      await client.getMultiTokenPeriodEnforcerAvailableAmountFromDelegation({
+      await client.getMultiTokenPeriodEnforcerAvailableAmount({
         delegation,
         delegationManager: customDelegationManager,
       });
@@ -127,7 +127,7 @@ describe('CaveatEnforcerClient', () => {
       const { read } = await import('../../src/DelegationFramework/MultiTokenPeriodEnforcer/methods/getAvailableAmount');
       vi.mocked(read).mockResolvedValue(mockResult);
 
-      await client.getMultiTokenPeriodEnforcerAvailableAmountFromDelegation({
+      await client.getMultiTokenPeriodEnforcerAvailableAmount({
         delegation,
         enforcerAddress: customEnforcerAddress,
       });
@@ -143,7 +143,7 @@ describe('CaveatEnforcerClient', () => {
     });
   });
 
-  describe('getErc20PeriodTransferEnforcerAvailableAmountFromDelegation', () => {
+  describe('getErc20PeriodTransferEnforcerAvailableAmount with delegation', () => {
     it('should successfully get available amount using client', async () => {
       const delegationWithErc20Caveat = {
         ...delegation,
@@ -165,7 +165,7 @@ describe('CaveatEnforcerClient', () => {
       const { read } = await import('../../src/DelegationFramework/ERC20PeriodTransferEnforcer/methods/getAvailableAmount');
       vi.mocked(read).mockResolvedValue(mockResult);
 
-      const result = await client.getErc20PeriodTransferEnforcerAvailableAmountFromDelegation({
+      const result = await client.getErc20PeriodTransferEnforcerAvailableAmount({
         delegation: delegationWithErc20Caveat,
       });
 
@@ -212,15 +212,10 @@ describe('CaveatEnforcerClient', () => {
   describe('Client type', () => {
     it('should have all expected methods', () => {
       expect(client).toHaveProperty('getMultiTokenPeriodEnforcerAvailableAmount');
-      expect(client).toHaveProperty('getMultiTokenPeriodEnforcerAvailableAmountFromDelegation');
       expect(client).toHaveProperty('getErc20PeriodTransferEnforcerAvailableAmount');
-      expect(client).toHaveProperty('getErc20PeriodTransferEnforcerAvailableAmountFromDelegation');
       expect(client).toHaveProperty('getErc20StreamingEnforcerAvailableAmount');
-      expect(client).toHaveProperty('getErc20StreamingEnforcerAvailableAmountFromDelegation');
       expect(client).toHaveProperty('getNativeTokenPeriodTransferEnforcerAvailableAmount');
-      expect(client).toHaveProperty('getNativeTokenPeriodTransferEnforcerAvailableAmountFromDelegation');
       expect(client).toHaveProperty('getNativeTokenStreamingEnforcerAvailableAmount');
-      expect(client).toHaveProperty('getNativeTokenStreamingEnforcerAvailableAmountFromDelegation');
     });
 
     it('should still have base client methods', () => {

--- a/packages/delegation-toolkit/test/actions/caveatEnforcerClient.test.ts
+++ b/packages/delegation-toolkit/test/actions/caveatEnforcerClient.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createPublicClient, http } from 'viem';
+import { mainnet } from 'viem/chains';
+import { hashDelegation } from '@metamask/delegation-core';
+import {
+  createCaveatEnforcerClient,
+  type CaveatEnforcerClient,
+  type DeleGatorEnvironment,
+  type Delegation,
+} from '../../src';
+
+// Mock the contract read functions
+vi.mock('../../src/DelegationFramework/MultiTokenPeriodEnforcer/methods/getAvailableAmount', () => ({
+  read: vi.fn(),
+}));
+
+vi.mock('../../src/DelegationFramework/ERC20PeriodTransferEnforcer/methods/getAvailableAmount', () => ({
+  read: vi.fn(),
+}));
+
+describe('CaveatEnforcerClient', () => {
+  let client: CaveatEnforcerClient;
+  let environment: DeleGatorEnvironment;
+  let delegation: Delegation;
+
+  beforeEach(() => {
+    const baseClient = createPublicClient({
+      chain: mainnet,
+      transport: http(),
+    });
+
+    environment = {
+      DelegationManager: '0x1234567890123456789012345678901234567890',
+      EntryPoint: '0x2345678901234567890123456789012345678901',
+      SimpleFactory: '0x3456789012345678901234567890123456789012',
+      implementations: {},
+      caveatEnforcers: {
+        MultiTokenPeriodEnforcer: '0x4567890123456789012345678901234567890123',
+        ERC20PeriodTransferEnforcer: '0x5678901234567890123456789012345678901234',
+        ERC20StreamingEnforcer: '0x6789012345678901234567890123456789012345',
+        NativeTokenPeriodTransferEnforcer: '0x7890123456789012345678901234567890123456',
+        NativeTokenStreamingEnforcer: '0x8901234567890123456789012345678901234567',
+      },
+    };
+
+    client = createCaveatEnforcerClient({
+      client: baseClient,
+      environment,
+    });
+
+    delegation = {
+      delegate: '0x1111111111111111111111111111111111111111',
+      delegator: '0x2222222222222222222222222222222222222222',
+      authority: '0x0000000000000000000000000000000000000000000000000000000000000000',
+      caveats: [
+        {
+          enforcer: '0x4567890123456789012345678901234567890123',
+          terms: '0x1234567890abcdef',
+          args: '0xfedcba0987654321',
+        },
+      ],
+      salt: '0x0000000000000000000000000000000000000000000000000000000000000001',
+      signature: '0xabcdef1234567890',
+    };
+  });
+
+  describe('getMultiTokenPeriodEnforcerAvailableAmountFromDelegation', () => {
+    it('should successfully get available amount using client', async () => {
+      const mockResult = {
+        availableAmount: 1000n,
+        isNewPeriod: true,
+        currentPeriod: 1n,
+      };
+
+      const { read } = await import('../../src/DelegationFramework/MultiTokenPeriodEnforcer/methods/getAvailableAmount');
+      vi.mocked(read).mockResolvedValue(mockResult);
+
+      const result = await client.getMultiTokenPeriodEnforcerAvailableAmountFromDelegation({
+        delegation,
+      });
+
+      expect(result).toEqual(mockResult);
+      expect(read).toHaveBeenCalledWith({
+        client: expect.any(Object),
+        contractAddress: environment.caveatEnforcers.MultiTokenPeriodEnforcer,
+        delegationHash: hashDelegation(delegation),
+        delegationManager: environment.DelegationManager,
+        terms: delegation.caveats[0].terms,
+        args: delegation.caveats[0].args,
+      });
+    });
+
+    it('should use custom delegation manager when provided', async () => {
+      const customDelegationManager = '0x9999999999999999999999999999999999999999';
+      const mockResult = {
+        availableAmount: 1000n,
+        isNewPeriod: true,
+        currentPeriod: 1n,
+      };
+
+      const { read } = await import('../../src/DelegationFramework/MultiTokenPeriodEnforcer/methods/getAvailableAmount');
+      vi.mocked(read).mockResolvedValue(mockResult);
+
+      await client.getMultiTokenPeriodEnforcerAvailableAmountFromDelegation({
+        delegation,
+        delegationManager: customDelegationManager,
+      });
+
+      expect(read).toHaveBeenCalledWith({
+        client: expect.any(Object),
+        contractAddress: environment.caveatEnforcers.MultiTokenPeriodEnforcer,
+        delegationHash: hashDelegation(delegation),
+        delegationManager: customDelegationManager,
+        terms: delegation.caveats[0].terms,
+        args: delegation.caveats[0].args,
+      });
+    });
+
+    it('should use custom enforcer address when provided', async () => {
+      const customEnforcerAddress = '0x9999999999999999999999999999999999999999';
+      const mockResult = {
+        availableAmount: 1000n,
+        isNewPeriod: true,
+        currentPeriod: 1n,
+      };
+
+      const { read } = await import('../../src/DelegationFramework/MultiTokenPeriodEnforcer/methods/getAvailableAmount');
+      vi.mocked(read).mockResolvedValue(mockResult);
+
+      await client.getMultiTokenPeriodEnforcerAvailableAmountFromDelegation({
+        delegation,
+        enforcerAddress: customEnforcerAddress,
+      });
+
+      expect(read).toHaveBeenCalledWith({
+        client: expect.any(Object),
+        contractAddress: customEnforcerAddress,
+        delegationHash: hashDelegation(delegation),
+        delegationManager: environment.DelegationManager,
+        terms: delegation.caveats[0].terms,
+        args: delegation.caveats[0].args,
+      });
+    });
+  });
+
+  describe('getErc20PeriodTransferEnforcerAvailableAmountFromDelegation', () => {
+    it('should successfully get available amount using client', async () => {
+      const delegationWithErc20Caveat = {
+        ...delegation,
+        caveats: [
+          {
+            enforcer: '0x5678901234567890123456789012345678901234',
+            terms: '0x1234567890abcdef',
+            args: '0x',
+          },
+        ],
+      };
+
+      const mockResult = {
+        availableAmount: 1000n,
+        isNewPeriod: true,
+        currentPeriod: 1n,
+      };
+
+      const { read } = await import('../../src/DelegationFramework/ERC20PeriodTransferEnforcer/methods/getAvailableAmount');
+      vi.mocked(read).mockResolvedValue(mockResult);
+
+      const result = await client.getErc20PeriodTransferEnforcerAvailableAmountFromDelegation({
+        delegation: delegationWithErc20Caveat,
+      });
+
+      expect(result).toEqual(mockResult);
+      expect(read).toHaveBeenCalledWith({
+        client: expect.any(Object),
+        contractAddress: environment.caveatEnforcers.ERC20PeriodTransferEnforcer,
+        delegationHash: hashDelegation(delegationWithErc20Caveat),
+        delegationManager: environment.DelegationManager,
+        terms: delegationWithErc20Caveat.caveats[0].terms,
+      });
+    });
+  });
+
+  describe('Legacy methods still work', () => {
+    it('should support legacy getMultiTokenPeriodEnforcerAvailableAmount method', async () => {
+      const mockResult = {
+        availableAmount: 1000n,
+        isNewPeriod: true,
+        currentPeriod: 1n,
+      };
+
+      const { read } = await import('../../src/DelegationFramework/MultiTokenPeriodEnforcer/methods/getAvailableAmount');
+      vi.mocked(read).mockResolvedValue(mockResult);
+
+      const result = await client.getMultiTokenPeriodEnforcerAvailableAmount({
+        delegationHash: hashDelegation(delegation),
+        terms: delegation.caveats[0].terms,
+        args: delegation.caveats[0].args,
+      });
+
+      expect(result).toEqual(mockResult);
+      expect(read).toHaveBeenCalledWith({
+        client: expect.any(Object),
+        contractAddress: environment.caveatEnforcers.MultiTokenPeriodEnforcer,
+        delegationHash: hashDelegation(delegation),
+        delegationManager: environment.DelegationManager,
+        terms: delegation.caveats[0].terms,
+        args: delegation.caveats[0].args,
+      });
+    });
+  });
+
+  describe('Client type', () => {
+    it('should have all expected methods', () => {
+      expect(client).toHaveProperty('getMultiTokenPeriodEnforcerAvailableAmount');
+      expect(client).toHaveProperty('getMultiTokenPeriodEnforcerAvailableAmountFromDelegation');
+      expect(client).toHaveProperty('getErc20PeriodTransferEnforcerAvailableAmount');
+      expect(client).toHaveProperty('getErc20PeriodTransferEnforcerAvailableAmountFromDelegation');
+      expect(client).toHaveProperty('getErc20StreamingEnforcerAvailableAmount');
+      expect(client).toHaveProperty('getErc20StreamingEnforcerAvailableAmountFromDelegation');
+      expect(client).toHaveProperty('getNativeTokenPeriodTransferEnforcerAvailableAmount');
+      expect(client).toHaveProperty('getNativeTokenPeriodTransferEnforcerAvailableAmountFromDelegation');
+      expect(client).toHaveProperty('getNativeTokenStreamingEnforcerAvailableAmount');
+      expect(client).toHaveProperty('getNativeTokenStreamingEnforcerAvailableAmountFromDelegation');
+    });
+
+    it('should still have base client methods', () => {
+      expect(client).toHaveProperty('getBlockNumber');
+      expect(client).toHaveProperty('getBalance');
+      expect(client).toHaveProperty('readContract');
+    });
+  });
+});

--- a/packages/delegation-toolkit/test/actions/getCaveatAvailableAmount.test.ts
+++ b/packages/delegation-toolkit/test/actions/getCaveatAvailableAmount.test.ts
@@ -3,11 +3,11 @@ import { createPublicClient, http } from 'viem';
 import { mainnet } from 'viem/chains';
 import { hashDelegation } from '@metamask/delegation-core';
 import {
-  getMultiTokenPeriodEnforcerAvailableAmountFromDelegation,
-  getErc20PeriodTransferEnforcerAvailableAmountFromDelegation,
-  getErc20StreamingEnforcerAvailableAmountFromDelegation,
-  getNativeTokenPeriodTransferEnforcerAvailableAmountFromDelegation,
-  getNativeTokenStreamingEnforcerAvailableAmountFromDelegation,
+  getMultiTokenPeriodEnforcerAvailableAmount,
+  getErc20PeriodTransferEnforcerAvailableAmount,
+  getErc20StreamingEnforcerAvailableAmount,
+  getNativeTokenPeriodTransferEnforcerAvailableAmount,
+  getNativeTokenStreamingEnforcerAvailableAmount,
   NoMatchingCaveatError,
   MultipleMatchingCaveatsError,
   type DeleGatorEnvironment,
@@ -76,7 +76,7 @@ describe('Delegation-based Caveat Enforcer Actions', () => {
     };
   });
 
-  describe('getMultiTokenPeriodEnforcerAvailableAmountFromDelegation', () => {
+  describe('getMultiTokenPeriodEnforcerAvailableAmount with delegation', () => {
     it('should successfully get available amount with matching caveat', async () => {
       const mockResult = {
         availableAmount: 1000n,
@@ -87,7 +87,7 @@ describe('Delegation-based Caveat Enforcer Actions', () => {
       const { read } = await import('../../src/DelegationFramework/MultiTokenPeriodEnforcer/methods/getAvailableAmount');
       vi.mocked(read).mockResolvedValue(mockResult);
 
-      const result = await getMultiTokenPeriodEnforcerAvailableAmountFromDelegation(
+      const result = await getMultiTokenPeriodEnforcerAvailableAmount(
         client,
         environment,
         { delegation },
@@ -117,7 +117,7 @@ describe('Delegation-based Caveat Enforcer Actions', () => {
       };
 
       await expect(
-        getMultiTokenPeriodEnforcerAvailableAmountFromDelegation(
+        getMultiTokenPeriodEnforcerAvailableAmount(
           client,
           environment,
           { delegation: delegationWithoutMatchingCaveat },
@@ -143,7 +143,7 @@ describe('Delegation-based Caveat Enforcer Actions', () => {
       };
 
       await expect(
-        getMultiTokenPeriodEnforcerAvailableAmountFromDelegation(
+        getMultiTokenPeriodEnforcerAvailableAmount(
           client,
           environment,
           { delegation: delegationWithMultipleMatchingCaveats },
@@ -162,7 +162,7 @@ describe('Delegation-based Caveat Enforcer Actions', () => {
       const { read } = await import('../../src/DelegationFramework/MultiTokenPeriodEnforcer/methods/getAvailableAmount');
       vi.mocked(read).mockResolvedValue(mockResult);
 
-      await getMultiTokenPeriodEnforcerAvailableAmountFromDelegation(
+      await getMultiTokenPeriodEnforcerAvailableAmount(
         client,
         environment,
         { delegation, delegationManager: customDelegationManager },
@@ -189,7 +189,7 @@ describe('Delegation-based Caveat Enforcer Actions', () => {
       const { read } = await import('../../src/DelegationFramework/MultiTokenPeriodEnforcer/methods/getAvailableAmount');
       vi.mocked(read).mockResolvedValue(mockResult);
 
-      await getMultiTokenPeriodEnforcerAvailableAmountFromDelegation(
+      await getMultiTokenPeriodEnforcerAvailableAmount(
         client,
         environment,
         { delegation, enforcerAddress: customEnforcerAddress },
@@ -206,7 +206,7 @@ describe('Delegation-based Caveat Enforcer Actions', () => {
     });
   });
 
-  describe('getErc20PeriodTransferEnforcerAvailableAmountFromDelegation', () => {
+  describe('getErc20PeriodTransferEnforcerAvailableAmount with delegation', () => {
     it('should successfully get available amount with matching caveat', async () => {
       const delegationWithErc20Caveat = {
         ...delegation,
@@ -228,7 +228,7 @@ describe('Delegation-based Caveat Enforcer Actions', () => {
       const { read } = await import('../../src/DelegationFramework/ERC20PeriodTransferEnforcer/methods/getAvailableAmount');
       vi.mocked(read).mockResolvedValue(mockResult);
 
-      const result = await getErc20PeriodTransferEnforcerAvailableAmountFromDelegation(
+      const result = await getErc20PeriodTransferEnforcerAvailableAmount(
         client,
         environment,
         { delegation: delegationWithErc20Caveat },
@@ -245,7 +245,7 @@ describe('Delegation-based Caveat Enforcer Actions', () => {
     });
   });
 
-  describe('getErc20StreamingEnforcerAvailableAmountFromDelegation', () => {
+  describe('getErc20StreamingEnforcerAvailableAmount with delegation', () => {
     it('should successfully get available amount with matching caveat', async () => {
       const delegationWithErc20StreamingCaveat = {
         ...delegation,
@@ -265,7 +265,7 @@ describe('Delegation-based Caveat Enforcer Actions', () => {
       const { read } = await import('../../src/DelegationFramework/ERC20StreamingEnforcer/methods/getAvailableAmount');
       vi.mocked(read).mockResolvedValue(mockResult);
 
-      const result = await getErc20StreamingEnforcerAvailableAmountFromDelegation(
+      const result = await getErc20StreamingEnforcerAvailableAmount(
         client,
         environment,
         { delegation: delegationWithErc20StreamingCaveat },
@@ -282,7 +282,7 @@ describe('Delegation-based Caveat Enforcer Actions', () => {
     });
   });
 
-  describe('getNativeTokenPeriodTransferEnforcerAvailableAmountFromDelegation', () => {
+  describe('getNativeTokenPeriodTransferEnforcerAvailableAmount with delegation', () => {
     it('should successfully get available amount with matching caveat', async () => {
       const delegationWithNativeTokenCaveat = {
         ...delegation,
@@ -304,7 +304,7 @@ describe('Delegation-based Caveat Enforcer Actions', () => {
       const { read } = await import('../../src/DelegationFramework/NativeTokenPeriodTransferEnforcer/methods/getAvailableAmount');
       vi.mocked(read).mockResolvedValue(mockResult);
 
-      const result = await getNativeTokenPeriodTransferEnforcerAvailableAmountFromDelegation(
+      const result = await getNativeTokenPeriodTransferEnforcerAvailableAmount(
         client,
         environment,
         { delegation: delegationWithNativeTokenCaveat },
@@ -321,7 +321,7 @@ describe('Delegation-based Caveat Enforcer Actions', () => {
     });
   });
 
-  describe('getNativeTokenStreamingEnforcerAvailableAmountFromDelegation', () => {
+  describe('getNativeTokenStreamingEnforcerAvailableAmount with delegation', () => {
     it('should successfully get available amount with matching caveat', async () => {
       const delegationWithNativeTokenStreamingCaveat = {
         ...delegation,
@@ -341,7 +341,7 @@ describe('Delegation-based Caveat Enforcer Actions', () => {
       const { read } = await import('../../src/DelegationFramework/NativeTokenStreamingEnforcer/methods/getAvailableAmount');
       vi.mocked(read).mockResolvedValue(mockResult);
 
-      const result = await getNativeTokenStreamingEnforcerAvailableAmountFromDelegation(
+      const result = await getNativeTokenStreamingEnforcerAvailableAmount(
         client,
         environment,
         { delegation: delegationWithNativeTokenStreamingCaveat },
@@ -366,7 +366,7 @@ describe('Delegation-based Caveat Enforcer Actions', () => {
       };
 
       await expect(
-        getMultiTokenPeriodEnforcerAvailableAmountFromDelegation(
+        getMultiTokenPeriodEnforcerAvailableAmount(
           client,
           environmentWithoutDelegationManager,
           { delegation },
@@ -384,7 +384,7 @@ describe('Delegation-based Caveat Enforcer Actions', () => {
       };
 
       await expect(
-        getMultiTokenPeriodEnforcerAvailableAmountFromDelegation(
+        getMultiTokenPeriodEnforcerAvailableAmount(
           client,
           environmentWithoutEnforcer,
           { delegation },

--- a/packages/delegation-toolkit/test/actions/getCaveatAvailableAmount.test.ts
+++ b/packages/delegation-toolkit/test/actions/getCaveatAvailableAmount.test.ts
@@ -8,8 +8,6 @@ import {
   getErc20StreamingEnforcerAvailableAmount,
   getNativeTokenPeriodTransferEnforcerAvailableAmount,
   getNativeTokenStreamingEnforcerAvailableAmount,
-  NoMatchingCaveatError,
-  MultipleMatchingCaveatsError,
   type DeleGatorEnvironment,
   type Delegation,
 } from '../../src';
@@ -104,7 +102,7 @@ describe('Delegation-based Caveat Enforcer Actions', () => {
       });
     });
 
-    it('should throw NoMatchingCaveatError when no matching caveat is found', async () => {
+    it('should throw Error when no matching caveat is found', async () => {
       const delegationWithoutMatchingCaveat = {
         ...delegation,
         caveats: [
@@ -122,10 +120,10 @@ describe('Delegation-based Caveat Enforcer Actions', () => {
           environment,
           { delegation: delegationWithoutMatchingCaveat },
         ),
-      ).rejects.toThrow(NoMatchingCaveatError);
+      ).rejects.toThrow('No caveat found with enforcer matching 0x4567890123456789012345678901234567890123');
     });
 
-    it('should throw MultipleMatchingCaveatsError when multiple matching caveats are found', async () => {
+    it('should throw Error when multiple matching caveats are found', async () => {
       const delegationWithMultipleMatchingCaveats = {
         ...delegation,
         caveats: [
@@ -148,7 +146,7 @@ describe('Delegation-based Caveat Enforcer Actions', () => {
           environment,
           { delegation: delegationWithMultipleMatchingCaveats },
         ),
-      ).rejects.toThrow(MultipleMatchingCaveatsError);
+      ).rejects.toThrow('Multiple caveats found with enforcer matching 0x4567890123456789012345678901234567890123');
     });
 
 

--- a/packages/delegation-toolkit/test/actions/getCaveatAvailableAmount.test.ts
+++ b/packages/delegation-toolkit/test/actions/getCaveatAvailableAmount.test.ts
@@ -1,0 +1,395 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createPublicClient, http } from 'viem';
+import { mainnet } from 'viem/chains';
+import { hashDelegation } from '@metamask/delegation-core';
+import {
+  getMultiTokenPeriodEnforcerAvailableAmountFromDelegation,
+  getErc20PeriodTransferEnforcerAvailableAmountFromDelegation,
+  getErc20StreamingEnforcerAvailableAmountFromDelegation,
+  getNativeTokenPeriodTransferEnforcerAvailableAmountFromDelegation,
+  getNativeTokenStreamingEnforcerAvailableAmountFromDelegation,
+  NoMatchingCaveatError,
+  MultipleMatchingCaveatsError,
+  type DeleGatorEnvironment,
+  type Delegation,
+} from '../../src';
+
+// Mock the contract read functions
+vi.mock('../../src/DelegationFramework/MultiTokenPeriodEnforcer/methods/getAvailableAmount', () => ({
+  read: vi.fn(),
+}));
+
+vi.mock('../../src/DelegationFramework/ERC20PeriodTransferEnforcer/methods/getAvailableAmount', () => ({
+  read: vi.fn(),
+}));
+
+vi.mock('../../src/DelegationFramework/ERC20StreamingEnforcer/methods/getAvailableAmount', () => ({
+  read: vi.fn(),
+}));
+
+vi.mock('../../src/DelegationFramework/NativeTokenPeriodTransferEnforcer/methods/getAvailableAmount', () => ({
+  read: vi.fn(),
+}));
+
+vi.mock('../../src/DelegationFramework/NativeTokenStreamingEnforcer/methods/getAvailableAmount', () => ({
+  read: vi.fn(),
+}));
+
+describe('Delegation-based Caveat Enforcer Actions', () => {
+  let client: ReturnType<typeof createPublicClient>;
+  let environment: DeleGatorEnvironment;
+  let delegation: Delegation;
+
+  beforeEach(() => {
+    client = createPublicClient({
+      chain: mainnet,
+      transport: http(),
+    });
+
+    environment = {
+      DelegationManager: '0x1234567890123456789012345678901234567890',
+      EntryPoint: '0x2345678901234567890123456789012345678901',
+      SimpleFactory: '0x3456789012345678901234567890123456789012',
+      implementations: {},
+      caveatEnforcers: {
+        MultiTokenPeriodEnforcer: '0x4567890123456789012345678901234567890123',
+        ERC20PeriodTransferEnforcer: '0x5678901234567890123456789012345678901234',
+        ERC20StreamingEnforcer: '0x6789012345678901234567890123456789012345',
+        NativeTokenPeriodTransferEnforcer: '0x7890123456789012345678901234567890123456',
+        NativeTokenStreamingEnforcer: '0x8901234567890123456789012345678901234567',
+      },
+    };
+
+    delegation = {
+      delegate: '0x1111111111111111111111111111111111111111',
+      delegator: '0x2222222222222222222222222222222222222222',
+      authority: '0x0000000000000000000000000000000000000000000000000000000000000000',
+      caveats: [
+        {
+          enforcer: '0x4567890123456789012345678901234567890123',
+          terms: '0x1234567890abcdef',
+          args: '0xfedcba0987654321',
+        },
+      ],
+      salt: '0x0000000000000000000000000000000000000000000000000000000000000001',
+      signature: '0xabcdef1234567890',
+    };
+  });
+
+  describe('getMultiTokenPeriodEnforcerAvailableAmountFromDelegation', () => {
+    it('should successfully get available amount with matching caveat', async () => {
+      const mockResult = {
+        availableAmount: 1000n,
+        isNewPeriod: true,
+        currentPeriod: 1n,
+      };
+
+      const { read } = await import('../../src/DelegationFramework/MultiTokenPeriodEnforcer/methods/getAvailableAmount');
+      vi.mocked(read).mockResolvedValue(mockResult);
+
+      const result = await getMultiTokenPeriodEnforcerAvailableAmountFromDelegation(
+        client,
+        environment,
+        { delegation },
+      );
+
+      expect(result).toEqual(mockResult);
+      expect(read).toHaveBeenCalledWith({
+        client,
+        contractAddress: environment.caveatEnforcers.MultiTokenPeriodEnforcer,
+        delegationHash: hashDelegation(delegation),
+        delegationManager: environment.DelegationManager,
+        terms: delegation.caveats[0].terms,
+        args: delegation.caveats[0].args,
+      });
+    });
+
+    it('should throw NoMatchingCaveatError when no matching caveat is found', async () => {
+      const delegationWithoutMatchingCaveat = {
+        ...delegation,
+        caveats: [
+          {
+            enforcer: '0x9999999999999999999999999999999999999999',
+            terms: '0x1234567890abcdef',
+            args: '0xfedcba0987654321',
+          },
+        ],
+      };
+
+      await expect(
+        getMultiTokenPeriodEnforcerAvailableAmountFromDelegation(
+          client,
+          environment,
+          { delegation: delegationWithoutMatchingCaveat },
+        ),
+      ).rejects.toThrow(NoMatchingCaveatError);
+    });
+
+    it('should throw MultipleMatchingCaveatsError when multiple matching caveats are found', async () => {
+      const delegationWithMultipleMatchingCaveats = {
+        ...delegation,
+        caveats: [
+          {
+            enforcer: '0x4567890123456789012345678901234567890123',
+            terms: '0x1234567890abcdef',
+            args: '0xfedcba0987654321',
+          },
+          {
+            enforcer: '0x4567890123456789012345678901234567890123',
+            terms: '0xabcdef1234567890',
+            args: '0x1234567890abcdef',
+          },
+        ],
+      };
+
+      await expect(
+        getMultiTokenPeriodEnforcerAvailableAmountFromDelegation(
+          client,
+          environment,
+          { delegation: delegationWithMultipleMatchingCaveats },
+        ),
+      ).rejects.toThrow(MultipleMatchingCaveatsError);
+    });
+
+    it('should use custom delegation manager when provided', async () => {
+      const customDelegationManager = '0x9999999999999999999999999999999999999999';
+      const mockResult = {
+        availableAmount: 1000n,
+        isNewPeriod: true,
+        currentPeriod: 1n,
+      };
+
+      const { read } = await import('../../src/DelegationFramework/MultiTokenPeriodEnforcer/methods/getAvailableAmount');
+      vi.mocked(read).mockResolvedValue(mockResult);
+
+      await getMultiTokenPeriodEnforcerAvailableAmountFromDelegation(
+        client,
+        environment,
+        { delegation, delegationManager: customDelegationManager },
+      );
+
+      expect(read).toHaveBeenCalledWith({
+        client,
+        contractAddress: environment.caveatEnforcers.MultiTokenPeriodEnforcer,
+        delegationHash: hashDelegation(delegation),
+        delegationManager: customDelegationManager,
+        terms: delegation.caveats[0].terms,
+        args: delegation.caveats[0].args,
+      });
+    });
+
+    it('should use custom enforcer address when provided', async () => {
+      const customEnforcerAddress = '0x9999999999999999999999999999999999999999';
+      const mockResult = {
+        availableAmount: 1000n,
+        isNewPeriod: true,
+        currentPeriod: 1n,
+      };
+
+      const { read } = await import('../../src/DelegationFramework/MultiTokenPeriodEnforcer/methods/getAvailableAmount');
+      vi.mocked(read).mockResolvedValue(mockResult);
+
+      await getMultiTokenPeriodEnforcerAvailableAmountFromDelegation(
+        client,
+        environment,
+        { delegation, enforcerAddress: customEnforcerAddress },
+      );
+
+      expect(read).toHaveBeenCalledWith({
+        client,
+        contractAddress: customEnforcerAddress,
+        delegationHash: hashDelegation(delegation),
+        delegationManager: environment.DelegationManager,
+        terms: delegation.caveats[0].terms,
+        args: delegation.caveats[0].args,
+      });
+    });
+  });
+
+  describe('getErc20PeriodTransferEnforcerAvailableAmountFromDelegation', () => {
+    it('should successfully get available amount with matching caveat', async () => {
+      const delegationWithErc20Caveat = {
+        ...delegation,
+        caveats: [
+          {
+            enforcer: '0x5678901234567890123456789012345678901234',
+            terms: '0x1234567890abcdef',
+            args: '0x',
+          },
+        ],
+      };
+
+      const mockResult = {
+        availableAmount: 1000n,
+        isNewPeriod: true,
+        currentPeriod: 1n,
+      };
+
+      const { read } = await import('../../src/DelegationFramework/ERC20PeriodTransferEnforcer/methods/getAvailableAmount');
+      vi.mocked(read).mockResolvedValue(mockResult);
+
+      const result = await getErc20PeriodTransferEnforcerAvailableAmountFromDelegation(
+        client,
+        environment,
+        { delegation: delegationWithErc20Caveat },
+      );
+
+      expect(result).toEqual(mockResult);
+      expect(read).toHaveBeenCalledWith({
+        client,
+        contractAddress: environment.caveatEnforcers.ERC20PeriodTransferEnforcer,
+        delegationHash: hashDelegation(delegationWithErc20Caveat),
+        delegationManager: environment.DelegationManager,
+        terms: delegationWithErc20Caveat.caveats[0].terms,
+      });
+    });
+  });
+
+  describe('getErc20StreamingEnforcerAvailableAmountFromDelegation', () => {
+    it('should successfully get available amount with matching caveat', async () => {
+      const delegationWithErc20StreamingCaveat = {
+        ...delegation,
+        caveats: [
+          {
+            enforcer: '0x6789012345678901234567890123456789012345',
+            terms: '0x1234567890abcdef',
+            args: '0x',
+          },
+        ],
+      };
+
+      const mockResult = {
+        availableAmount: 1000n,
+      };
+
+      const { read } = await import('../../src/DelegationFramework/ERC20StreamingEnforcer/methods/getAvailableAmount');
+      vi.mocked(read).mockResolvedValue(mockResult);
+
+      const result = await getErc20StreamingEnforcerAvailableAmountFromDelegation(
+        client,
+        environment,
+        { delegation: delegationWithErc20StreamingCaveat },
+      );
+
+      expect(result).toEqual(mockResult);
+      expect(read).toHaveBeenCalledWith({
+        client,
+        contractAddress: environment.caveatEnforcers.ERC20StreamingEnforcer,
+        delegationManager: environment.DelegationManager,
+        delegationHash: hashDelegation(delegationWithErc20StreamingCaveat),
+        terms: delegationWithErc20StreamingCaveat.caveats[0].terms,
+      });
+    });
+  });
+
+  describe('getNativeTokenPeriodTransferEnforcerAvailableAmountFromDelegation', () => {
+    it('should successfully get available amount with matching caveat', async () => {
+      const delegationWithNativeTokenCaveat = {
+        ...delegation,
+        caveats: [
+          {
+            enforcer: '0x7890123456789012345678901234567890123456',
+            terms: '0x1234567890abcdef',
+            args: '0x',
+          },
+        ],
+      };
+
+      const mockResult = {
+        availableAmount: 1000n,
+        isNewPeriod: true,
+        currentPeriod: 1n,
+      };
+
+      const { read } = await import('../../src/DelegationFramework/NativeTokenPeriodTransferEnforcer/methods/getAvailableAmount');
+      vi.mocked(read).mockResolvedValue(mockResult);
+
+      const result = await getNativeTokenPeriodTransferEnforcerAvailableAmountFromDelegation(
+        client,
+        environment,
+        { delegation: delegationWithNativeTokenCaveat },
+      );
+
+      expect(result).toEqual(mockResult);
+      expect(read).toHaveBeenCalledWith({
+        client,
+        contractAddress: environment.caveatEnforcers.NativeTokenPeriodTransferEnforcer,
+        delegationHash: hashDelegation(delegationWithNativeTokenCaveat),
+        delegationManager: environment.DelegationManager,
+        terms: delegationWithNativeTokenCaveat.caveats[0].terms,
+      });
+    });
+  });
+
+  describe('getNativeTokenStreamingEnforcerAvailableAmountFromDelegation', () => {
+    it('should successfully get available amount with matching caveat', async () => {
+      const delegationWithNativeTokenStreamingCaveat = {
+        ...delegation,
+        caveats: [
+          {
+            enforcer: '0x8901234567890123456789012345678901234567',
+            terms: '0x1234567890abcdef',
+            args: '0x',
+          },
+        ],
+      };
+
+      const mockResult = {
+        availableAmount: 1000n,
+      };
+
+      const { read } = await import('../../src/DelegationFramework/NativeTokenStreamingEnforcer/methods/getAvailableAmount');
+      vi.mocked(read).mockResolvedValue(mockResult);
+
+      const result = await getNativeTokenStreamingEnforcerAvailableAmountFromDelegation(
+        client,
+        environment,
+        { delegation: delegationWithNativeTokenStreamingCaveat },
+      );
+
+      expect(result).toEqual(mockResult);
+      expect(read).toHaveBeenCalledWith({
+        client,
+        contractAddress: environment.caveatEnforcers.NativeTokenStreamingEnforcer,
+        delegationManager: environment.DelegationManager,
+        delegationHash: hashDelegation(delegationWithNativeTokenStreamingCaveat),
+        terms: delegationWithNativeTokenStreamingCaveat.caveats[0].terms,
+      });
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should throw error when delegation manager is not found in environment', async () => {
+      const environmentWithoutDelegationManager = {
+        ...environment,
+        DelegationManager: undefined as any,
+      };
+
+      await expect(
+        getMultiTokenPeriodEnforcerAvailableAmountFromDelegation(
+          client,
+          environmentWithoutDelegationManager,
+          { delegation },
+        ),
+      ).rejects.toThrow('Delegation manager address not found');
+    });
+
+    it('should throw error when enforcer is not found in environment', async () => {
+      const environmentWithoutEnforcer = {
+        ...environment,
+        caveatEnforcers: {
+          ...environment.caveatEnforcers,
+          MultiTokenPeriodEnforcer: undefined as any,
+        },
+      };
+
+      await expect(
+        getMultiTokenPeriodEnforcerAvailableAmountFromDelegation(
+          client,
+          environmentWithoutEnforcer,
+          { delegation },
+        ),
+      ).rejects.toThrow('MultiTokenPeriodEnforcer not found in environment');
+    });
+  });
+});

--- a/packages/delegation-toolkit/test/actions/getCaveatAvailableAmount.test.ts
+++ b/packages/delegation-toolkit/test/actions/getCaveatAvailableAmount.test.ts
@@ -151,59 +151,7 @@ describe('Delegation-based Caveat Enforcer Actions', () => {
       ).rejects.toThrow(MultipleMatchingCaveatsError);
     });
 
-    it('should use custom delegation manager when provided', async () => {
-      const customDelegationManager = '0x9999999999999999999999999999999999999999';
-      const mockResult = {
-        availableAmount: 1000n,
-        isNewPeriod: true,
-        currentPeriod: 1n,
-      };
 
-      const { read } = await import('../../src/DelegationFramework/MultiTokenPeriodEnforcer/methods/getAvailableAmount');
-      vi.mocked(read).mockResolvedValue(mockResult);
-
-      await getMultiTokenPeriodEnforcerAvailableAmount(
-        client,
-        environment,
-        { delegation, delegationManager: customDelegationManager },
-      );
-
-      expect(read).toHaveBeenCalledWith({
-        client,
-        contractAddress: environment.caveatEnforcers.MultiTokenPeriodEnforcer,
-        delegationHash: hashDelegation(delegation),
-        delegationManager: customDelegationManager,
-        terms: delegation.caveats[0].terms,
-        args: delegation.caveats[0].args,
-      });
-    });
-
-    it('should use custom enforcer address when provided', async () => {
-      const customEnforcerAddress = '0x9999999999999999999999999999999999999999';
-      const mockResult = {
-        availableAmount: 1000n,
-        isNewPeriod: true,
-        currentPeriod: 1n,
-      };
-
-      const { read } = await import('../../src/DelegationFramework/MultiTokenPeriodEnforcer/methods/getAvailableAmount');
-      vi.mocked(read).mockResolvedValue(mockResult);
-
-      await getMultiTokenPeriodEnforcerAvailableAmount(
-        client,
-        environment,
-        { delegation, enforcerAddress: customEnforcerAddress },
-      );
-
-      expect(read).toHaveBeenCalledWith({
-        client,
-        contractAddress: customEnforcerAddress,
-        delegationHash: hashDelegation(delegation),
-        delegationManager: environment.DelegationManager,
-        terms: delegation.caveats[0].terms,
-        args: delegation.caveats[0].args,
-      });
-    });
   });
 
   describe('getErc20PeriodTransferEnforcerAvailableAmount with delegation', () => {

--- a/packages/delegator-e2e/test/caveats/caveatUtils.test.ts
+++ b/packages/delegator-e2e/test/caveats/caveatUtils.test.ts
@@ -132,12 +132,9 @@ describe('ERC20PeriodTransferEnforcer', () => {
       signature: await aliceSmartAccount.signDelegation({ delegation }),
     };
 
-    const delegationHash = getDelegationHashOffchain(signedDelegation);
-
     const beforeResult =
       await caveatClient.getErc20PeriodTransferEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
+        delegation: signedDelegation,
       });
 
     expect(beforeResult.availableAmount).toBe(periodAmount);
@@ -177,8 +174,7 @@ describe('ERC20PeriodTransferEnforcer', () => {
 
     const afterResult =
       await caveatClient.getErc20PeriodTransferEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
+        delegation: signedDelegation,
       });
 
     expect(afterResult.availableAmount).toBe(periodAmount - transferAmount);
@@ -216,12 +212,9 @@ describe('ERC20PeriodTransferEnforcer', () => {
       signature: await aliceSmartAccount.signDelegation({ delegation }),
     };
 
-    const delegationHash = getDelegationHashOffchain(signedDelegation);
-
-    const beforeResult =
+        const beforeResult =
       await caveatClient.getErc20PeriodTransferEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
+        delegation: signedDelegation,
       });
 
     expect(beforeResult.availableAmount).toBe(0n);
@@ -257,8 +250,7 @@ describe('ERC20PeriodTransferEnforcer', () => {
 
     const afterResult =
       await caveatClient.getErc20PeriodTransferEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
+        delegation: signedDelegation,
       });
 
     expect(afterResult.availableAmount).toBe(0n);
@@ -297,13 +289,10 @@ describe('ERC20PeriodTransferEnforcer', () => {
       signature: await aliceSmartAccount.signDelegation({ delegation }),
     };
 
-    const delegationHash = getDelegationHashOffchain(signedDelegation);
-
-    // Should be a new period, availableAmount reset to periodAmount
+        // Should be a new period, availableAmount reset to periodAmount
     const beforeResult =
       await caveatClient.getErc20PeriodTransferEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
+        delegation: signedDelegation,
       });
 
     expect(beforeResult.availableAmount).toBe(periodAmount);
@@ -343,8 +332,7 @@ describe('ERC20PeriodTransferEnforcer', () => {
 
     const afterResult =
       await caveatClient.getErc20PeriodTransferEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
+        delegation: signedDelegation,
       });
 
     expect(afterResult.availableAmount).toBe(periodAmount - transferAmount);
@@ -389,13 +377,10 @@ describe('ERC20StreamingEnforcer', () => {
     };
 
     // Get delegation hash
-    const delegationHash = getDelegationHashOffchain(signedDelegation);
-
-    // Check available amount before redemption
+        // Check available amount before redemption
     const beforeResult =
       await caveatClient.getErc20StreamingEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
+        delegation: signedDelegation,
       });
 
     // @note: This enforcer now simulates available amount before first use.
@@ -443,8 +428,7 @@ describe('ERC20StreamingEnforcer', () => {
     // Check available amount after redemption
     const afterResult =
       await caveatClient.getErc20StreamingEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
+        delegation: signedDelegation,
       });
 
     expect(afterResult.availableAmount).toBeGreaterThanOrEqual(
@@ -488,12 +472,9 @@ describe('ERC20StreamingEnforcer', () => {
       }),
     };
 
-    const delegationHash = getDelegationHashOffchain(signedDelegation);
-
-    const beforeResult =
+        const beforeResult =
       await caveatClient.getErc20StreamingEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
+        delegation: signedDelegation,
       });
 
     expect(beforeResult.availableAmount).toBe(0n);
@@ -528,8 +509,7 @@ describe('ERC20StreamingEnforcer', () => {
 
     const afterResult =
       await caveatClient.getErc20StreamingEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
+        delegation: signedDelegation,
       });
 
     expect(afterResult.availableAmount).toBe(0n);
@@ -570,12 +550,9 @@ describe('ERC20StreamingEnforcer', () => {
       }),
     };
 
-    const delegationHash = getDelegationHashOffchain(signedDelegation);
-
-    const beforeResult =
+        const beforeResult =
       await caveatClient.getErc20StreamingEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
+        delegation: signedDelegation,
       });
 
     // @note: This enforcer now simulates available amount before first use.
@@ -623,8 +600,7 @@ describe('ERC20StreamingEnforcer', () => {
 
     const afterResult =
       await caveatClient.getErc20StreamingEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
+        delegation: signedDelegation,
       });
 
     const expectedAmount =
@@ -671,18 +647,14 @@ describe('MultiTokenPeriodEnforcer', () => {
     };
 
     // Get delegation hash
-    const delegationHash = getDelegationHashOffchain(signedDelegation);
-
-    // Prepare args for multi-token enforcer (token selector)
+        // Prepare args for multi-token enforcer (token selector)
     const args = encodePacked(['uint256'], [BigInt(0)]); // token index 0
     signedDelegation.caveats[0].args = args;
 
     // Check available amount before redemption
     const beforeResult =
       await caveatClient.getMultiTokenPeriodEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
-        args,
+        delegation: signedDelegation,
       });
 
     expect(beforeResult.availableAmount).toBe(periodAmount);
@@ -725,9 +697,7 @@ describe('MultiTokenPeriodEnforcer', () => {
     // Check available amount after redemption
     const afterResult =
       await caveatClient.getMultiTokenPeriodEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
-        args,
+        delegation: signedDelegation,
       });
 
     expect(afterResult.availableAmount).toBe(0n); // All tokens were transferred
@@ -770,17 +740,13 @@ describe('MultiTokenPeriodEnforcer', () => {
       }),
     };
 
-    const delegationHash = getDelegationHashOffchain(signedDelegation);
-
-    // Prepare args for multi-token enforcer (token selector)
+        // Prepare args for multi-token enforcer (token selector)
     const args = encodePacked(['uint256'], [BigInt(0)]); // token index 0
     signedDelegation.caveats[0].args = args;
 
     const beforeResult =
       await caveatClient.getMultiTokenPeriodEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
-        args,
+        delegation: signedDelegation,
       });
 
     expect(beforeResult.availableAmount).toBe(0n);
@@ -816,9 +782,7 @@ describe('MultiTokenPeriodEnforcer', () => {
 
     const afterResult =
       await caveatClient.getMultiTokenPeriodEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
-        args,
+        delegation: signedDelegation,
       });
 
     expect(afterResult.availableAmount).toBe(0n);
@@ -860,17 +824,13 @@ describe('MultiTokenPeriodEnforcer', () => {
       }),
     };
 
-    const delegationHash = getDelegationHashOffchain(signedDelegation);
-
-    // Prepare args for multi-token enforcer (token selector)
+        // Prepare args for multi-token enforcer (token selector)
     const args = encodePacked(['uint256'], [BigInt(0)]); // token index 0
     signedDelegation.caveats[0].args = args;
 
     const beforeResult =
       await caveatClient.getMultiTokenPeriodEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
-        args,
+        delegation: signedDelegation,
       });
 
     expect(beforeResult.availableAmount).toBe(periodAmount);
@@ -910,9 +870,7 @@ describe('MultiTokenPeriodEnforcer', () => {
 
     const afterResult =
       await caveatClient.getMultiTokenPeriodEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
-        args,
+        delegation: signedDelegation,
       });
 
     expect(afterResult.availableAmount).toBe(periodAmount - transferAmount);
@@ -954,13 +912,10 @@ describe('NativeTokenPeriodTransferEnforcer', () => {
     };
 
     // Get delegation hash
-    const delegationHash = getDelegationHashOffchain(signedDelegation);
-
-    // Check available amount before redemption
+        // Check available amount before redemption
     const beforeResult =
       await caveatClient.getNativeTokenPeriodTransferEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
+        delegation: signedDelegation,
       });
 
     expect(beforeResult.availableAmount).toBe(periodAmount);
@@ -1004,8 +959,7 @@ describe('NativeTokenPeriodTransferEnforcer', () => {
     // Check available amount after redemption
     const afterResult =
       await caveatClient.getNativeTokenPeriodTransferEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
+        delegation: signedDelegation,
       });
 
     expect(afterResult.availableAmount).toBe(periodAmount - transferAmount);
@@ -1044,12 +998,9 @@ describe('NativeTokenPeriodTransferEnforcer', () => {
       }),
     };
 
-    const delegationHash = getDelegationHashOffchain(signedDelegation);
-
-    const beforeResult =
+        const beforeResult =
       await caveatClient.getNativeTokenPeriodTransferEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
+        delegation: signedDelegation,
       });
 
     expect(beforeResult.availableAmount).toBe(0n);
@@ -1081,8 +1032,7 @@ describe('NativeTokenPeriodTransferEnforcer', () => {
 
     const afterResult =
       await caveatClient.getNativeTokenPeriodTransferEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
+        delegation: signedDelegation,
       });
 
     expect(afterResult.availableAmount).toBe(0n);
@@ -1120,12 +1070,9 @@ describe('NativeTokenPeriodTransferEnforcer', () => {
       }),
     };
 
-    const delegationHash = getDelegationHashOffchain(signedDelegation);
-
-    const beforeResult =
+        const beforeResult =
       await caveatClient.getNativeTokenPeriodTransferEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
+        delegation: signedDelegation,
       });
 
     expect(beforeResult.availableAmount).toBe(periodAmount);
@@ -1161,8 +1108,7 @@ describe('NativeTokenPeriodTransferEnforcer', () => {
 
     const afterResult =
       await caveatClient.getNativeTokenPeriodTransferEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
+        delegation: signedDelegation,
       });
 
     expect(afterResult.availableAmount).toBe(periodAmount - transferAmount);
@@ -1205,13 +1151,10 @@ describe('NativeTokenStreamingEnforcer', () => {
     };
 
     // Get delegation hash
-    const delegationHash = getDelegationHashOffchain(signedDelegation);
-
-    // Check available amount before redemption
+        // Check available amount before redemption
     const beforeResult =
       await caveatClient.getNativeTokenStreamingEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
+        delegation: signedDelegation,
       });
 
     // @note: This enforcer now simulates available amount before first use.
@@ -1255,8 +1198,7 @@ describe('NativeTokenStreamingEnforcer', () => {
     // Check available amount after redemption
     const afterResult =
       await caveatClient.getNativeTokenStreamingEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
+        delegation: signedDelegation,
       });
 
     expect(afterResult.availableAmount).toBeGreaterThanOrEqual(
@@ -1298,12 +1240,9 @@ describe('NativeTokenStreamingEnforcer', () => {
       }),
     };
 
-    const delegationHash = getDelegationHashOffchain(signedDelegation);
-
-    const beforeResult =
+        const beforeResult =
       await caveatClient.getNativeTokenStreamingEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
+        delegation: signedDelegation,
       });
 
     expect(beforeResult.availableAmount).toBe(0n);
@@ -1334,8 +1273,7 @@ describe('NativeTokenStreamingEnforcer', () => {
 
     const afterResult =
       await caveatClient.getNativeTokenStreamingEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
+        delegation: signedDelegation,
       });
 
     expect(afterResult.availableAmount).toBe(0n);
@@ -1374,12 +1312,9 @@ describe('NativeTokenStreamingEnforcer', () => {
       }),
     };
 
-    const delegationHash = getDelegationHashOffchain(signedDelegation);
-
-    const beforeResult =
+        const beforeResult =
       await caveatClient.getNativeTokenStreamingEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
+        delegation: signedDelegation,
       });
 
     // @note: This enforcer now simulates available amount before first use.
@@ -1423,8 +1358,7 @@ describe('NativeTokenStreamingEnforcer', () => {
 
     const afterResult =
       await caveatClient.getNativeTokenStreamingEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
+        delegation: signedDelegation,
       });
 
     const expectedAmount =
@@ -1468,13 +1402,10 @@ describe('Generic caveat utils functionality', () => {
     };
 
     // Get delegation hash
-    const delegationHash = getDelegationHashOffchain(signedDelegation);
-
-    // Use generic method
+        // Use generic method
     const result =
       await caveatClient.getErc20PeriodTransferEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
+        delegation: signedDelegation,
       });
 
     expect(result.availableAmount).toBe(periodAmount);
@@ -1510,14 +1441,10 @@ describe('Generic caveat utils functionality', () => {
     };
 
     // Get delegation hash
-    const delegationHash = getDelegationHashOffchain(signedDelegation);
-
-    // This should fail with custom delegation manager since it's not the real one
+        // This should fail with custom delegation manager since it's not the real one
     const result =
       await caveatClient.getErc20PeriodTransferEnforcerAvailableAmount({
-        delegationHash,
-        terms: delegation.caveats[0].terms,
-        delegationManager: customDelegationManager,
+        delegation: signedDelegation,delegationManager: customDelegationManager,
       });
 
     // Should still return a result, check structure
@@ -1551,11 +1478,8 @@ describe('Individual action functions vs client extension methods', () => {
       signature: await aliceSmartAccount.signDelegation({ delegation }),
     };
 
-    const delegationHash = getDelegationHashOffchain(signedDelegation);
-    const params = {
-      delegationHash,
-      terms: delegation.caveats[0].terms,
-    };
+        const params = {
+      delegation: signedDelegation,};
 
     // Test both approaches
     const [clientResult, functionResult] = await Promise.all([
@@ -1597,11 +1521,8 @@ describe('Individual action functions vs client extension methods', () => {
       signature: await aliceSmartAccount.signDelegation({ delegation }),
     };
 
-    const delegationHash = getDelegationHashOffchain(signedDelegation);
-    const params = {
-      delegationHash,
-      terms: delegation.caveats[0].terms,
-    };
+        const params = {
+      delegation: signedDelegation,};
 
     // Test both approaches
     const [clientResult, functionResult] = await Promise.all([
@@ -1642,13 +1563,9 @@ describe('Individual action functions vs client extension methods', () => {
       signature: await aliceSmartAccount.signDelegation({ delegation }),
     };
 
-    const delegationHash = getDelegationHashOffchain(signedDelegation);
-    const args = encodePacked(['uint256'], [BigInt(0)]); // token index 0
+        const args = encodePacked(['uint256'], [BigInt(0)]); // token index 0
     const params = {
-      delegationHash,
-      terms: delegation.caveats[0].terms,
-      args,
-    };
+      delegation: signedDelegation,};
 
     // Test both approaches
     const [clientResult, functionResult] = await Promise.all([
@@ -1687,11 +1604,8 @@ describe('Individual action functions vs client extension methods', () => {
       signature: await aliceSmartAccount.signDelegation({ delegation }),
     };
 
-    const delegationHash = getDelegationHashOffchain(signedDelegation);
-    const params = {
-      delegationHash,
-      terms: delegation.caveats[0].terms,
-    };
+        const params = {
+      delegation: signedDelegation,};
 
     // Test both approaches
     const [clientResult, functionResult] = await Promise.all([
@@ -1732,11 +1646,8 @@ describe('Individual action functions vs client extension methods', () => {
       signature: await aliceSmartAccount.signDelegation({ delegation }),
     };
 
-    const delegationHash = getDelegationHashOffchain(signedDelegation);
-    const params = {
-      delegationHash,
-      terms: delegation.caveats[0].terms,
-    };
+        const params = {
+      delegation: signedDelegation,};
 
     // Test both approaches
     const [clientResult, functionResult] = await Promise.all([
@@ -1775,11 +1686,8 @@ describe('Individual action functions vs client extension methods', () => {
       signature: await aliceSmartAccount.signDelegation({ delegation }),
     };
 
-    const delegationHash = getDelegationHashOffchain(signedDelegation);
-    const customParams = {
-      delegationHash,
-      terms: delegation.caveats[0].terms,
-      delegationManager: aliceSmartAccount.environment.DelegationManager,
+        const customParams = {
+      delegation: signedDelegation,delegationManager: aliceSmartAccount.environment.DelegationManager,
       enforcerAddress:
         aliceSmartAccount.environment.caveatEnforcers
           .ERC20PeriodTransferEnforcer,


### PR DESCRIPTION
## 📝 Description

This PR refactors the caveat enforcer actions and client within the `@metamask/delegation-toolkit` package to simplify their API and improve developer experience.

## 🔄 What Changed?

-   **Simplified Action Parameters**: All caveat enforcer actions (e.g., `getMultiTokenPeriodEnforcerAvailableAmount`) now exclusively accept a single parameter: `{ delegation: Delegation }`.
-   **Internal Delegation Handling**: Actions now internally handle hashing the delegation and finding the relevant caveat based on the enforcer address from the `environment`.
-   **Removed Explicit Address Parameters**: `delegationManager` and `enforcerAddress` are no longer accepted as explicit parameters; they are always derived from the `environment` object.
-   **Consolidated Parameter Type**: All action parameter types are unified into a single `CaveatEnforcerParams` type.
-   **Standardized Error Handling**: Custom error types (`NoMatchingCaveatError`, `MultipleMatchingCaveatsError`) have been replaced with standard `Error` objects for consistency.
-   **Client Export Location**: `createCaveatEnforcerClient` and its type `CaveatEnforcerClient` are now exported directly from the main `@metamask/delegation-toolkit` package.
-   **Internal Import Path**: The `hashDelegation` utility is now imported directly from its internal filepath (`../delegation`).
-   **Test Updates**: Unit tests and E2E tests (`packages/delegator-e2e/test/caveats/caveatUtils.test.ts`) have been updated to reflect the new, simplified API.

## 🚀 Why?

-   **Improved Developer Experience**: Callers no longer need to manually hash delegations, extract caveat terms/args, or resolve enforcer/delegation manager addresses. The API is significantly more ergonomic, requiring only the `Delegation` object.
-   **Simplified API**: A single, consistent parameter type across all caveat enforcer actions reduces cognitive load and improves predictability.
-   **Centralized Client Access**: Moving the `CaveatEnforcerClient` to the main package export makes it more discoverable and directly accessible.
-   **Standard Practices**: Adopting standard `Error` objects aligns with common JavaScript error handling patterns.

## 🧪 How to Test?

-   [ ] Manual testing steps:
    1.  Import `createCaveatEnforcerClient` from `@metamask/delegation-toolkit` and verify it can be instantiated.
    2.  Call any caveat enforcer action (e.g., `client.getMultiTokenPeriodEnforcerAvailableAmount`) passing only a `{ delegation: Delegation }` object and confirm correct results.
    3.  Test scenarios where a delegation contains no matching caveat or multiple matching caveats for a specific enforcer, ensuring a standard `Error` with a descriptive message is thrown.
-   [ ] Automated tests added/updated
-   [ ] All existing tests pass

## ⚠️ Breaking Changes

-   [ ] Breaking changes (describe below):
    -   The API for all caveat enforcer actions has changed. Callers must now pass a `{ delegation: Delegation }` object. The previous parameters (`delegationHash`, `terms`, `args`, `delegationManager`, `enforcerAddress`) are no longer accepted.
    -   Custom error types (`NoMatchingCaveatError`, `MultipleMatchingCaveatsError`) are removed; standard `Error` objects are thrown instead.

## 📋 Checklist

-   [x] Code follows the project's coding standards
-   [x] Self-review completed
-   [ ] Documentation updated (if needed)
-   [x] Tests added/updated
-   [ ] Changelog updated (if needed)
-   [ ] All CI checks pass

## 🔗 Related Issues

Closes #
Related to #

## 📚 Additional Notes

This PR is the result of several iterations to refine the API based on feedback, leading to a much cleaner and more intuitive interface for interacting with caveat enforcer contracts.

---
<a href="https://cursor.com/background-agent?bcId=bc-729d14e5-89eb-4a92-b88a-e83eeb1b2c07">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-729d14e5-89eb-4a92-b88a-e83eeb1b2c07">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

