### PR TITLE
fix: timeout waiting for dependencies when running e2e tests

### DIFF
--- a/packages/delegator-e2e/src/await-dependencies.ts
+++ b/packages/delegator-e2e/src/await-dependencies.ts
@@ -69,17 +69,14 @@ const deployEnvironment = async () => {
 
   const timeoutRef = setTimeout(() => (hasTimedOut = true), TIMEOUT_MS);
 
-  await waitFor('Blockchain node', nodeUrl);
-
-  const waitingForDependencies = Promise.all([
+  await Promise.all([
+    waitFor('Blockchain node', nodeUrl),
     waitFor('Bundler', bundlerUrl),
     waitFor('Mock paymaster', paymasterUrl),
   ]);
 
   const environment = await deployEnvironment();
   await writeFile('./.gator-env.json', JSON.stringify(environment, null, 2));
-
-  await waitingForDependencies;
 
   clearTimeout(timeoutRef);
 


### PR DESCRIPTION
## 📝 Description

When preparing dependencies for e2e tests, we introduced an "improvement" that only waited for the blockchain to be available before deploying the delegation environment. This introduced a nonce mismatch because the same deployer account is used to deploy the contracts for the paymaster, resulting in failed paymaster startup.

## 🔄 What Changed?

Instead of waiting for the blockchain before deploying the delegation environment, we wait for the blockchain, bundler, and paymaster dependencies all to be available.

## 🧪 How to Test?

Describe how to test these changes:

e2e tests should consistently run (and not timeout when setting up the dependencies).