### PR TITLE
Release/10.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.0]
+
 ## [9.0.0]
 
 ## [8.0.0]
 
 ## [7.0.0]
 
-[Unreleased]: https://github.com/MetaMask/delegation-toolkit/compare/delegator-sdk-monorepo@9.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/delegation-toolkit/compare/delegator-sdk-monorepo@10.0.0...HEAD
+[10.0.0]: https://github.com/MetaMask/delegation-toolkit/compare/delegator-sdk-monorepo@9.0.0...delegator-sdk-monorepo@10.0.0
 [9.0.0]: https://github.com/MetaMask/delegation-toolkit/compare/delegator-sdk-monorepo@8.0.0...delegator-sdk-monorepo@9.0.0
 [8.0.0]: https://github.com/MetaMask/delegation-toolkit/compare/delegator-sdk-monorepo@7.0.0...delegator-sdk-monorepo@8.0.0
 [7.0.0]: https://github.com/MetaMask/delegation-toolkit/releases/tag/delegator-sdk-monorepo@7.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "delegator-sdk-monorepo",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "license": "(MIT-0 OR Apache-2.0)",
   "private": true,
   "repository": {

--- a/packages/delegation-core/CHANGELOG.md
+++ b/packages/delegation-core/CHANGELOG.md
@@ -7,11 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Uncategorized
-
-- Adds Contract Utils (Caveats, Delegation) ([#45](https://github.com/MetaMask/delegation-toolkit/pull/45))
-- feat: added contract utils
-
 ## [0.2.0-rc.1]
 
 ### Added
@@ -29,6 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add @metamask/delegation-core package, providing utility types, delegation hashing, and terms encoding for a limited set of caveat enforcers.
 
-[Unreleased]: https://github.com/MetaMask/delegation-toolkit/compare/@metamask/delegation-core@0.2.0-rc.1...HEAD
-[0.2.0-rc.1]: https://github.com/MetaMask/delegation-toolkit/compare/@metamask/delegation-core@0.1.0...@metamask/delegation-core@0.2.0-rc.1
-[0.1.0]: https://github.com/MetaMask/delegation-toolkit/releases/tag/@metamask/delegation-core@0.1.0
+[Unreleased]: https://github.com/metamask/delegation-toolkit/compare/@metamask/delegation-core@0.2.0-rc.1...HEAD
+[0.2.0-rc.1]: https://github.com/metamask/delegation-toolkit/compare/@metamask/delegation-core@0.1.0...@metamask/delegation-core@0.2.0-rc.1
+[0.1.0]: https://github.com/metamask/delegation-toolkit/releases/tag/@metamask/delegation-core@0.1.0

--- a/packages/delegation-core/CHANGELOG.md
+++ b/packages/delegation-core/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Adds Contract Utils (Caveats, Delegation) ([#45](https://github.com/MetaMask/delegation-toolkit/pull/45))
+- feat: added contract utils
+
 ## [0.2.0-rc.1]
 
 ### Added
@@ -24,6 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add @metamask/delegation-core package, providing utility types, delegation hashing, and terms encoding for a limited set of caveat enforcers.
 
-[Unreleased]: https://github.com/metamask/delegation-toolkit/compare/@metamask/delegation-core@0.2.0-rc.1...HEAD
-[0.2.0-rc.1]: https://github.com/metamask/delegation-toolkit/compare/@metamask/delegation-core@0.1.0...@metamask/delegation-core@0.2.0-rc.1
-[0.1.0]: https://github.com/metamask/delegation-toolkit/releases/tag/@metamask/delegation-core@0.1.0
+[Unreleased]: https://github.com/MetaMask/delegation-toolkit/compare/@metamask/delegation-core@0.2.0-rc.1...HEAD
+[0.2.0-rc.1]: https://github.com/MetaMask/delegation-toolkit/compare/@metamask/delegation-core@0.1.0...@metamask/delegation-core@0.2.0-rc.1
+[0.1.0]: https://github.com/MetaMask/delegation-toolkit/releases/tag/@metamask/delegation-core@0.1.0

--- a/packages/delegation-toolkit/CHANGELOG.md
+++ b/packages/delegation-toolkit/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- Introducing Caveat "Scopes" ([#51](https://github.com/MetaMask/delegation-toolkit/pull/51))
+- Merge branch 'main' into feat/scopes2
+- chore: deleted scope types
+- chore: using string names for scopes, added e2e tests
+- refactor: separated scopes, and deleted enums
+- Add exhaustiveness check to scope resolution switch statement
+- Remove SpecificActionErc20TransferBatch scope
+- Introduce caveat scopes - Add scope-based caveat builders for common delegation patterns - Update delegation factory functions to require environment and scope configuration - Move CoreCaveatBuilder into it's own file - Move resolveCaveats into it's own file
+
 ## [0.13.0-rc.2]
 
 ### Added
@@ -32,6 +43,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a bug where `sendTransactionWithDelegation` failed whenever `value` was specified in the parameters. ([#30](https://github.com/metamask/delegation-toolkit/pull/30))
 
-[Unreleased]: https://github.com/metamask/delegation-toolkit/compare/@metamask/delegation-toolkit@0.13.0-rc.2...HEAD
-[0.13.0-rc.2]: https://github.com/metamask/delegation-toolkit/compare/@metamask/delegation-toolkit@0.13.0-rc.1...@metamask/delegation-toolkit@0.13.0-rc.2
-[0.13.0-rc.1]: https://github.com/metamask/delegation-toolkit/releases/tag/@metamask/delegation-toolkit@0.13.0-rc.1
+[Unreleased]: https://github.com/MetaMask/delegation-toolkit/compare/@metamask/delegation-toolkit@0.13.0-rc.2...HEAD
+[0.13.0-rc.2]: https://github.com/MetaMask/delegation-toolkit/compare/@metamask/delegation-toolkit@0.13.0-rc.1...@metamask/delegation-toolkit@0.13.0-rc.2
+[0.13.0-rc.1]: https://github.com/MetaMask/delegation-toolkit/releases/tag/@metamask/delegation-toolkit@0.13.0-rc.1

--- a/packages/delegation-toolkit/CHANGELOG.md
+++ b/packages/delegation-toolkit/CHANGELOG.md
@@ -9,16 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.13.0-rc.3]
 
-### Uncategorized
+### Added
 
-- Introducing Caveat "Scopes" ([#51](https://github.com/MetaMask/delegation-toolkit/pull/51))
-- Merge branch 'main' into feat/scopes2
-- chore: deleted scope types
-- chore: using string names for scopes, added e2e tests
-- refactor: separated scopes, and deleted enums
-- Add exhaustiveness check to scope resolution switch statement
-- Remove SpecificActionErc20TransferBatch scope
-- Introduce caveat scopes - Add scope-based caveat builders for common delegation patterns - Update delegation factory functions to require environment and scope configuration - Move CoreCaveatBuilder into it's own file - Move resolveCaveats into it's own file
+- Delegation Scopes and a declarative API to define delegation caveats ([#51](https://github.com/MetaMask/delegation-toolkit/pull/51))
 
 ## [0.13.0-rc.2]
 
@@ -45,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a bug where `sendTransactionWithDelegation` failed whenever `value` was specified in the parameters. ([#30](https://github.com/metamask/delegation-toolkit/pull/30))
 
-[Unreleased]: https://github.com/MetaMask/delegation-toolkit/compare/@metamask/delegation-toolkit@0.13.0-rc.3...HEAD
-[0.13.0-rc.3]: https://github.com/MetaMask/delegation-toolkit/compare/@metamask/delegation-toolkit@0.13.0-rc.2...@metamask/delegation-toolkit@0.13.0-rc.3
-[0.13.0-rc.2]: https://github.com/MetaMask/delegation-toolkit/compare/@metamask/delegation-toolkit@0.13.0-rc.1...@metamask/delegation-toolkit@0.13.0-rc.2
-[0.13.0-rc.1]: https://github.com/MetaMask/delegation-toolkit/releases/tag/@metamask/delegation-toolkit@0.13.0-rc.1
+[Unreleased]: https://github.com/metamask/delegation-toolkit/compare/@metamask/delegation-toolkit@0.13.0-rc.3...HEAD
+[0.13.0-rc.3]: https://github.com/metamask/delegation-toolkit/compare/@metamask/delegation-toolkit@0.13.0-rc.2...@metamask/delegation-toolkit@0.13.0-rc.3
+[0.13.0-rc.2]: https://github.com/metamask/delegation-toolkit/compare/@metamask/delegation-toolkit@0.13.0-rc.1...@metamask/delegation-toolkit@0.13.0-rc.2
+[0.13.0-rc.1]: https://github.com/metamask/delegation-toolkit/releases/tag/@metamask/delegation-toolkit@0.13.0-rc.1

--- a/packages/delegation-toolkit/CHANGELOG.md
+++ b/packages/delegation-toolkit/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0-rc.3]
+
 ### Uncategorized
 
 - Introducing Caveat "Scopes" ([#51](https://github.com/MetaMask/delegation-toolkit/pull/51))
@@ -43,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a bug where `sendTransactionWithDelegation` failed whenever `value` was specified in the parameters. ([#30](https://github.com/metamask/delegation-toolkit/pull/30))
 
-[Unreleased]: https://github.com/MetaMask/delegation-toolkit/compare/@metamask/delegation-toolkit@0.13.0-rc.2...HEAD
+[Unreleased]: https://github.com/MetaMask/delegation-toolkit/compare/@metamask/delegation-toolkit@0.13.0-rc.3...HEAD
+[0.13.0-rc.3]: https://github.com/MetaMask/delegation-toolkit/compare/@metamask/delegation-toolkit@0.13.0-rc.2...@metamask/delegation-toolkit@0.13.0-rc.3
 [0.13.0-rc.2]: https://github.com/MetaMask/delegation-toolkit/compare/@metamask/delegation-toolkit@0.13.0-rc.1...@metamask/delegation-toolkit@0.13.0-rc.2
 [0.13.0-rc.1]: https://github.com/MetaMask/delegation-toolkit/releases/tag/@metamask/delegation-toolkit@0.13.0-rc.1

--- a/packages/delegation-toolkit/package.json
+++ b/packages/delegation-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/delegation-toolkit",
-  "version": "0.13.0-rc.2",
+  "version": "0.13.0-rc.3",
   "type": "module",
   "description": "The Delegation Toolkit built on top of Viem - a library for interacting with DeleGator Smart Accounts",
   "license": "(MIT-0 OR Apache-2.0)",


### PR DESCRIPTION
Releases: @metamask/delegation-toolkit@0.13.0-rc.3

### Added

- Delegation Scopes and a declarative API to define delegation caveats ([#51](https://github.com/MetaMask/delegation-toolkit/pull/51))