### PR TITLE
Improve declarative delegation interface

### DIFF
--- a/packages/delegation-toolkit/src/delegation.ts
+++ b/packages/delegation-toolkit/src/delegation.ts
@@ -193,10 +193,9 @@ type BaseCreateDelegationOptions = {
   environment: DeleGatorEnvironment;
   scope: ScopeConfig;
   from: Hex;
-  caveats: Caveats;
+  caveats?: Caveats;
   parentDelegation?: Delegation | Hex;
   salt?: Hex;
-  allowInsecureUnrestrictedDelegation?: boolean;
 };
 
 /**

--- a/packages/delegation-toolkit/test/DelegationFramework/DelegationManager/delegationManagement.test.ts
+++ b/packages/delegation-toolkit/test/DelegationFramework/DelegationManager/delegationManagement.test.ts
@@ -91,7 +91,6 @@ describe('DelegationManager - Delegation Management', () => {
           targets: [alice.address],
           selectors: ['0x00000000'],
         },
-        caveats: [],
       });
 
       const encodedData = DelegationManager.encode.disableDelegation({
@@ -117,7 +116,6 @@ describe('DelegationManager - Delegation Management', () => {
           targets: [alice.address],
           selectors: ['0x00000000'],
         },
-        caveats: [],
       });
 
       const encodedData = DelegationManager.encode.enableDelegation({
@@ -143,7 +141,6 @@ describe('DelegationManager - Delegation Management', () => {
           targets: [alice.address],
           selectors: ['0x00000000'],
         },
-        caveats: [],
       });
 
       const execution = createExecution({

--- a/packages/delegation-toolkit/test/delegation.test.ts
+++ b/packages/delegation-toolkit/test/delegation.test.ts
@@ -242,7 +242,6 @@ describe('createDelegation', () => {
       to: mockDelegate,
       from: mockDelegator,
       scope: erc20Scope,
-      caveats: [],
     });
 
     expect(result).to.deep.equal({
@@ -271,6 +270,24 @@ describe('createDelegation', () => {
       authority: ROOT_AUTHORITY,
       caveats: [...erc20ScopeCaveats, mockCaveat],
       salt: customSalt,
+      signature: '0x',
+    });
+  });
+
+  it('should create a delegation with scope-only caveats when caveats parameter is omitted', () => {
+    const result = createDelegation({
+      environment: delegatorEnvironment,
+      scope: erc20Scope,
+      to: mockDelegate,
+      from: mockDelegator,
+    });
+
+    expect(result).to.deep.equal({
+      delegate: mockDelegate,
+      delegator: mockDelegator,
+      authority: ROOT_AUTHORITY,
+      caveats: [...erc20ScopeCaveats],
+      salt: '0x',
       signature: '0x',
     });
   });
@@ -364,6 +381,23 @@ describe('createOpenDelegation', () => {
       authority: ROOT_AUTHORITY,
       caveats: [...erc20ScopeCaveats, mockCaveat],
       salt: customSalt,
+      signature: '0x',
+    });
+  });
+
+  it('should create an open delegation with scope-only caveats when caveats parameter is omitted', () => {
+    const result = createOpenDelegation({
+      environment: delegatorEnvironment,
+      scope: erc20Scope,
+      from: mockDelegator,
+    });
+
+    expect(result).to.deep.equal({
+      delegate: '0x0000000000000000000000000000000000000a11',
+      delegator: mockDelegator,
+      authority: ROOT_AUTHORITY,
+      caveats: [...erc20ScopeCaveats],
+      salt: '0x',
       signature: '0x',
     });
   });

--- a/packages/delegator-e2e/contracts/src/PayableReceiver.sol
+++ b/packages/delegator-e2e/contracts/src/PayableReceiver.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @title PayableReceiver
+ * @dev A simple contract for testing calldata restrictions with payable functions.
+ * Used in e2e tests to validate that delegated calls with specific calldata work correctly.
+ */
+contract PayableReceiver {
+    uint256 public totalReceived;
+    uint256 public callCount;
+
+    event EthReceived(address indexed sender, uint256 amount, uint256 totalReceived);
+
+    /**
+     * @dev Payable function that accepts ETH with no parameters
+     * Perfect for testing exactCalldata and allowedCalldata restrictions
+     */
+    function receiveEth() external payable {
+        totalReceived += msg.value;
+        callCount += 1;
+
+        emit EthReceived(msg.sender, msg.value, totalReceived);
+    }
+
+    /**
+     * @dev Another payable function with different calldata for testing allowedCalldata patterns
+     */
+    function receiveEthAlternative() external payable {
+        totalReceived += msg.value;
+        callCount += 1;
+
+        emit EthReceived(msg.sender, msg.value, totalReceived);
+    }
+
+    /**
+     * @dev Get the contract's current ETH balance
+     */
+    function getBalance() external view returns (uint256) {
+        return address(this).balance;
+    }
+
+    /**
+     * @dev Reset counters for testing (only for testing purposes)
+     */
+    function reset() external {
+        totalReceived = 0;
+        callCount = 0;
+    }
+}

--- a/packages/delegator-e2e/external-integration-tests/infuraBundlerClient.test.ts
+++ b/packages/delegator-e2e/external-integration-tests/infuraBundlerClient.test.ts
@@ -316,7 +316,6 @@ test('complete delegation workflow with dynamic gas pricing', async () => {
       type: 'nativeTokenTransferAmount',
       maxAmount: 0n,
     },
-    caveats: [],
   });
 
   // Step 4: Sign delegation

--- a/packages/delegator-e2e/test/actions/infuraBundlerClient.test.ts
+++ b/packages/delegator-e2e/test/actions/infuraBundlerClient.test.ts
@@ -97,7 +97,6 @@ test('infuraBundlerClient should work for delegation redemption', async () => {
       type: 'nativeTokenTransferAmount',
       maxAmount: 0n,
     },
-    caveats: [],
   });
 
   const signedDelegation = {

--- a/packages/delegator-e2e/test/caveats/allowedMethods.test.ts
+++ b/packages/delegator-e2e/test/caveats/allowedMethods.test.ts
@@ -297,7 +297,6 @@ const runScopeTest_expectSuccess = async (
       targets,
       selectors,
     },
-    caveats: [],
   });
 
   const signedDelegation = {
@@ -366,7 +365,6 @@ const runScopeTest_expectFailure = async (
       targets,
       selectors,
     },
-    caveats: [],
   });
 
   const signedDelegation = {

--- a/packages/delegator-e2e/test/caveats/caveatUtils.test.ts
+++ b/packages/delegator-e2e/test/caveats/caveatUtils.test.ts
@@ -124,7 +124,6 @@ describe('ERC20PeriodTransferEnforcer', () => {
         periodDuration,
         startDate: currentTime,
       },
-      caveats: [],
     });
 
     const signedDelegation = {
@@ -204,7 +203,6 @@ describe('ERC20PeriodTransferEnforcer', () => {
         periodDuration,
         startDate: futureStartDate,
       },
-      caveats: [],
     });
 
     const signedDelegation = {
@@ -281,7 +279,6 @@ describe('ERC20PeriodTransferEnforcer', () => {
         periodDuration,
         startDate,
       },
-      caveats: [],
     });
 
     const signedDelegation = {
@@ -366,7 +363,6 @@ describe('ERC20StreamingEnforcer', () => {
         amountPerSecond,
         startTime: currentTime,
       },
-      caveats: [],
     });
 
     const signedDelegation = {
@@ -462,7 +458,6 @@ describe('ERC20StreamingEnforcer', () => {
         amountPerSecond,
         startTime: futureStartTime,
       },
-      caveats: [],
     });
 
     const signedDelegation = {
@@ -540,7 +535,6 @@ describe('ERC20StreamingEnforcer', () => {
         amountPerSecond,
         startTime: pastStartTime,
       },
-      caveats: [],
     });
 
     const signedDelegation = {
@@ -907,7 +901,6 @@ describe('NativeTokenPeriodTransferEnforcer', () => {
         periodDuration,
         startDate: currentTime,
       },
-      caveats: [],
     });
 
     const signedDelegation = {
@@ -994,7 +987,6 @@ describe('NativeTokenPeriodTransferEnforcer', () => {
         periodDuration,
         startDate: futureStartDate,
       },
-      caveats: [],
     });
 
     const signedDelegation = {
@@ -1066,7 +1058,6 @@ describe('NativeTokenPeriodTransferEnforcer', () => {
         periodDuration,
         startDate,
       },
-      caveats: [],
     });
 
     const signedDelegation = {
@@ -1146,7 +1137,6 @@ describe('NativeTokenStreamingEnforcer', () => {
         amountPerSecond,
         startTime: currentTime,
       },
-      caveats: [],
     });
 
     const signedDelegation = {
@@ -1236,7 +1226,6 @@ describe('NativeTokenStreamingEnforcer', () => {
         amountPerSecond,
         startTime: futureStartTime,
       },
-      caveats: [],
     });
 
     const signedDelegation = {
@@ -1308,7 +1297,6 @@ describe('NativeTokenStreamingEnforcer', () => {
         amountPerSecond,
         startTime: pastStartTime,
       },
-      caveats: [],
     });
 
     const signedDelegation = {
@@ -1397,7 +1385,6 @@ describe('Generic caveat utils functionality', () => {
         periodDuration,
         startDate: currentTime,
       },
-      caveats: [],
     });
 
     const signedDelegation = {
@@ -1436,7 +1423,6 @@ describe('Individual action functions vs client extension methods', () => {
         periodDuration,
         startDate: currentTime,
       },
-      caveats: [],
     });
 
     const signedDelegation = {
@@ -1480,7 +1466,6 @@ describe('Individual action functions vs client extension methods', () => {
         amountPerSecond,
         startTime: currentTime,
       },
-      caveats: [],
     });
 
     const signedDelegation = {
@@ -1568,7 +1553,6 @@ describe('Individual action functions vs client extension methods', () => {
         periodDuration,
         startDate: currentTime,
       },
-      caveats: [],
     });
 
     const signedDelegation = {
@@ -1611,7 +1595,6 @@ describe('Individual action functions vs client extension methods', () => {
         amountPerSecond,
         startTime: currentTime,
       },
-      caveats: [],
     });
 
     const signedDelegation = {

--- a/packages/delegator-e2e/test/caveats/erc20PeriodTransfer.test.ts
+++ b/packages/delegator-e2e/test/caveats/erc20PeriodTransfer.test.ts
@@ -968,7 +968,6 @@ const runScopeTest_expectSuccess = async (
       periodDuration,
       startDate,
     },
-    caveats: [],
   });
 
   const signedDelegation = {
@@ -1064,7 +1063,6 @@ const runScopeTest_expectFailure = async (
       periodDuration,
       startDate,
     },
-    caveats: [],
   });
 
   const signedDelegation = {

--- a/packages/delegator-e2e/test/caveats/erc20Streaming.test.ts
+++ b/packages/delegator-e2e/test/caveats/erc20Streaming.test.ts
@@ -854,7 +854,6 @@ const runScopeTest_expectSuccess = async (
       amountPerSecond,
       startTime,
     },
-    caveats: [],
   });
 
   const signedDelegation = {
@@ -952,7 +951,6 @@ const runScopeTest_expectFailure = async (
       amountPerSecond,
       startTime,
     },
-    caveats: [],
   });
 
   const signedDelegation = {

--- a/packages/delegator-e2e/test/caveats/erc20TransferAmount.test.ts
+++ b/packages/delegator-e2e/test/caveats/erc20TransferAmount.test.ts
@@ -328,7 +328,6 @@ const runScopeTest_expectSuccess = async (
       tokenAddress: erc20TokenAddress,
       maxAmount,
     },
-    caveats: [],
   });
 
   const signedDelegation = {
@@ -420,7 +419,6 @@ const runScopeTest_expectFailure = async (
       tokenAddress: erc20TokenAddress,
       maxAmount,
     },
-    caveats: [],
   });
 
   const signedDelegation = {

--- a/packages/delegator-e2e/test/caveats/erc721Transfer.test.ts
+++ b/packages/delegator-e2e/test/caveats/erc721Transfer.test.ts
@@ -343,7 +343,6 @@ const runScopeTest_expectSuccess = async (
       tokenAddress: erc721TokenAddress,
       tokenId,
     },
-    caveats: [],
   });
 
   const signedDelegation = {
@@ -442,7 +441,6 @@ const runScopeTest_expectFailure = async (
       tokenAddress: erc721TokenAddress,
       tokenId: allowedTokenId,
     },
-    caveats: [],
   });
 
   const signedDelegation = {

--- a/packages/delegator-e2e/test/caveats/ownershipTransfer.test.ts
+++ b/packages/delegator-e2e/test/caveats/ownershipTransfer.test.ts
@@ -102,7 +102,6 @@ describe('Ownership Transfer Caveat', () => {
         type: 'ownershipTransfer',
         contractAddress,
       },
-      caveats: [],
     });
 
     // Sign the delegation
@@ -166,7 +165,6 @@ describe('Ownership Transfer Caveat', () => {
         type: 'ownershipTransfer',
         contractAddress, // Only allows this specific contract
       },
-      caveats: [],
     });
 
     // Sign the delegation
@@ -250,7 +248,6 @@ describe('Ownership Transfer Caveat', () => {
         type: 'ownershipTransfer',
         contractAddress,
       },
-      caveats: [],
     });
 
     const signedDelegation = {
@@ -308,7 +305,6 @@ describe('Ownership Transfer Caveat', () => {
         type: 'ownershipTransfer',
         contractAddress, // Only allows this specific contract
       },
-      caveats: [],
     });
 
     const signedDelegation = {

--- a/packages/delegator-e2e/test/delegateAndRedeem.test.ts
+++ b/packages/delegator-e2e/test/delegateAndRedeem.test.ts
@@ -102,7 +102,6 @@ test('maincase: Bob increments the counter with a delegation from Alice', async 
       targets: [aliceCounterContractAddress],
       selectors: ['increment()'],
     },
-    caveats: [],
   });
 
   const signedDelegation = {
@@ -212,7 +211,6 @@ test("Bob attempts to increment the counter with a delegation from Alice that do
       targets: [aliceCounterContractAddress],
       selectors: ['notTheRightFunction()'],
     },
-    caveats: [],
   });
 
   const signedDelegation = {
@@ -294,7 +292,6 @@ test('Bob increments the counter with a delegation from a multisig account', asy
       targets: [counterContract.address],
       selectors: ['increment()'],
     },
-    caveats: [],
   });
 
   // Get signatures from each signer

--- a/packages/delegator-e2e/test/delegationManagement.test.ts
+++ b/packages/delegator-e2e/test/delegationManagement.test.ts
@@ -86,7 +86,6 @@ test('delegation management lifecycle: create, disable, enable, and check status
       targets: [aliceCounter.address],
       selectors: ['increment()'],
     },
-    caveats: [],
   });
 
   const signedDelegation = {
@@ -256,7 +255,6 @@ test('only delegator can disable their own delegation', async () => {
       targets: [aliceCounter.address],
       selectors: ['increment()'],
     },
-    caveats: [],
   });
 
   // Bob attempts to disable Alice's delegation (should fail)
@@ -290,7 +288,6 @@ test('only delegator can enable their own delegation', async () => {
       targets: [aliceCounter.address],
       selectors: ['increment()'],
     },
-    caveats: [],
   });
 
   // Alice disables the delegation first
@@ -347,7 +344,6 @@ test('disabling non-existent delegation should succeed silently', async () => {
       targets: [aliceCounter.address],
       selectors: ['increment()'],
     },
-    caveats: [],
   });
 
   // Alice disables the delegation even though it was never used
@@ -395,7 +391,6 @@ test('can check delegation status using disabledDelegations', async () => {
       targets: [aliceCounter.address],
       selectors: ['increment()'],
     },
-    caveats: [],
   });
 
   const delegation2 = createDelegation({
@@ -407,7 +402,6 @@ test('can check delegation status using disabledDelegations', async () => {
       targets: [aliceCounter.address],
       selectors: ['decrement()'],
     },
-    caveats: [],
   });
 
   const delegationHash1 = getDelegationHashOffchain(delegation1);


### PR DESCRIPTION
## 📝 Description

Improves the declarative delegation interface developer experience by making caveats optional, removing unnecessary parameters, and adding calldata support to native token scopes.

## 🔄 What Changed?

List the specific changes made:

- Made caveats parameter optional in createDelegation and createOpenDelegation functions
- Removed allowInsecureFullAuthorizationDelegation parameter from createDelegation and createOpenDelegation (kept in signDelegation and CaveatBuilder)
- Added calldata support to native token scopes (nativeTokenTransfer, nativeTokenStreaming, nativeTokenPeriodic)
- Added exactCalldata and allowedCalldata parameters to native token scope configurations
- Updated resolveCaveats function to handle optional caveats parameter
- Created comprehensive E2E tests for calldata functionality with new PayableReceiver smart contract
- Added helper functions for deploying and interacting with test contracts

## 🚀 Why?

Explain the motivation behind these changes:

- Better Developer Experience: Developers no longer need to pass empty arrays when using scopes without additional caveats
- Cleaner API: Removed redundant parameter that's no longer relevant since delegations always have caveats from scopes
- Enhanced Flexibility: Developers can now specify calldata restrictions when transferring native tokens, enabling more precise control over delegated operations
- Improved Testing: E2E tests now use real contract interactions instead of hardcoded calldata, providing more realistic validation

## 🧪 How to Test?

Describe how to test these changes:

- [ ] Manual testing steps:

- Create a delegation using createDelegation without specifying caveats parameter
- Create a delegation with native token scope including exactCalldata or allowedCalldata
- Verify delegation creation works with scope-only caveats

- [ ] Automated tests added/updated
- [ ] All existing tests pass

## ⚠️ Breaking Changes

List any breaking changes:
- [x] Breaking changes (describe below):

- Removed allowInsecureFullAuthorizationDelegation parameter from createDelegation and createOpenDelegation functions

Updated native token scope type definitions to include optional calldata parameters

## 📋 Checklist

Check off completed items:

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] Changelog updated (if needed)
- [ ] All CI checks pass

## 🔗 Related Issues

Closes # https://app.zenhub.com/workspaces/readable-permissions-67982ce51eb4360029b2c1a1/issues/gh/metamask/delegator-readable-permissions/345

## 📚 Additional Notes

The PayableReceiver.sol contract was created specifically for testing calldata restrictions in E2E tests, providing a realistic target for delegated contract calls
Helper functions in test/utils/helpers.ts now return Promise<bigint> directly to avoid type casting in tests
All native token scope tests now perform proper end-to-end validation by creating, signing, and redeeming delegations on-chain
Error message assertions updated to match actual smart contract revert messages (invalid-calldata instead of previous placeholder messages)
