### PR TITLE
Export MetaMaskBasePermissionData type

### DIFF
--- a/packages/7715-permission-types/src/index.ts
+++ b/packages/7715-permission-types/src/index.ts
@@ -18,4 +18,5 @@ export type {
     PermissionResponse,
     RevokeExecutionPermissionRequestParams,
     RevokeExecutionPermissionResponseResult,
+    MetaMaskBasePermissionData,
 } from './types';


### PR DESCRIPTION
## Description
 
Expose `MetaMaskBasePermissionData` type in `@metamask/7715-permission-types` package to reduce type duplication in consumer packages.

## Related Issues

Related to # https://github.com/MetaMask/core/pull/6379


