### PR TITLE
replace usage of Node's Buffer with browser-friendly code

### DIFF
--- a/packages/delegation-toolkit/test/webAuthn.test.ts
+++ b/packages/delegation-toolkit/test/webAuthn.test.ts
@@ -283,5 +283,12 @@ describe('webAuthn', () => {
 
       expect(userVerified).to.equal(false);
     });
+    it('should throw an error if the authenticator flags are not found at the expected offset', () => {
+      const flags = 0b11111011;
+
+      expect(() => parseAuthenticatorFlags(toHex(flags))).to.throw(
+        'Authenticator flags not found in authenticator data',
+      );
+    });
   });
 });


### PR DESCRIPTION
## 📝 Description

This PR makes the `delegation-toolkit` package compatible with environments where Node.js's `Buffer` global is not available.

## 🔄 What Changed?

List the specific changes made:
- `packages/delegation-toolkit/src/webAuthn.ts`: `parseAuthenticatorFlags` changed to use Viem's `hexToBytes` in combination with `Uint8Array`

## 🚀 Why?

Explain the motivation behind these changes:
- I'm developing a vanilla JS browser-side application that calls `toMetaMaskSmartAccount` and ran into an error because `Buffer` is not defined on the browser.

## 🧪 How to Test?

Describe how to test these changes:

- [X] Manual testing steps:
 1. Create a vanilla JS script that creates a MetaMask smart account instance with `toMetamaskSmartAccount`, using the hybrid implementation
 2. Use viem's "sendUserOperation" with that account 
 3. After signing the operation with your passkey, you'll get an error similar to:
```
Uncaught (in promise) ReferenceError: Buffer is not defined
    parseAuthenticatorFlags webAuthn.ts:150
    encodeDeleGatorSignature webAuthn.ts:108
    encodeSignature signatory.ts:78
    promise callback*signTypedData signatory.ts:92
    signUserOperation2 toMetaMaskSmartAccount.ts:159
    sendUserOperation sendUserOperation.ts:138
    sendUserOperation bundler.ts:292
    createAccount index.js:57
    async* index.html:10
```
- [ ] Automated tests added/updated
- [X] All existing tests pass

## ⚠️ Breaking Changes

List any breaking changes:

- [X] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [X] Code follows the project's coding standards
- [X] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] Changelog updated (if needed)
- [ ] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches parseAuthenticatorFlags to viem hexToBytes/Uint8Array with a bounds check, and adds a unit test for missing flags.
> 
> - **Delegation Toolkit**:
>   - **webAuthn.ts**: Replace Node `Buffer` usage in `parseAuthenticatorFlags` with `hexToBytes` + `Uint8Array`; add error when flags byte is missing.
> - **Tests**:
>   - `webAuthn.test.ts`: Add test asserting an error when authenticator flags are not found at the expected offset.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 688f14c0187accb2a597950629342ba3e5a61c54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->