### PR TITLE
Fix MultiTokenPeriodBuilder to accept a config object

### DIFF
--- a/packages/delegation-toolkit/src/caveatBuilder/multiTokenPeriodBuilder.ts
+++ b/packages/delegation-toolkit/src/caveatBuilder/multiTokenPeriodBuilder.ts
@@ -22,7 +22,9 @@ export type TokenPeriodConfig = {
   startDate: number;
 };
 
-export type MultiTokenPeriodBuilderConfig = TokenPeriodConfig[];
+export type MultiTokenPeriodBuilderConfig = {
+  tokenConfigs: TokenPeriodConfig[];
+};
 
 export const multiTokenPeriod = 'multiTokenPeriod';
 
@@ -32,27 +34,30 @@ export const multiTokenPeriod = 'multiTokenPeriod';
  * Each token can have its own period amount, duration, and start date.
  *
  * @param environment - The DeleGator environment.
- * @param configs - The configurations for the MultiTokenPeriodBuilder.
+ * @param config - The configuration for the MultiTokenPeriodBuilder.
+ * @param config.tokenConfigs - The token configurations for the MultiTokenPeriodBuilder.
  * @returns The caveat object for the MultiTokenPeriodEnforcer.
  */
 export const multiTokenPeriodBuilder = (
   environment: DeleGatorEnvironment,
-  configs: MultiTokenPeriodBuilderConfig,
+  config: MultiTokenPeriodBuilderConfig,
 ): Caveat => {
-  if (!configs || configs.length === 0) {
-    throw new Error('MultiTokenPeriodBuilder: configs array cannot be empty');
+  if (!config?.tokenConfigs || config.tokenConfigs.length === 0) {
+    throw new Error(
+      'MultiTokenPeriodBuilder: tokenConfigs array cannot be empty',
+    );
   }
 
-  configs.forEach((config) => {
-    if (!isAddress(config.token)) {
-      throw new Error(`Invalid token address: ${String(config.token)}`);
+  config.tokenConfigs.forEach((tokenConfig) => {
+    if (!isAddress(tokenConfig.token)) {
+      throw new Error(`Invalid token address: ${String(tokenConfig.token)}`);
     }
 
-    if (config.periodAmount <= 0) {
+    if (tokenConfig.periodAmount <= 0) {
       throw new Error('Invalid period amount: must be greater than 0');
     }
 
-    if (config.periodDuration <= 0) {
+    if (tokenConfig.periodDuration <= 0) {
       throw new Error('Invalid period duration: must be greater than 0');
     }
   });
@@ -62,7 +67,7 @@ export const multiTokenPeriodBuilder = (
   // - 32 bytes for periodAmount
   // - 32 bytes for periodDuration
   // - 32 bytes for startDate
-  const termsArray = configs.reduce<Hex[]>(
+  const termsArray = config.tokenConfigs.reduce<Hex[]>(
     (acc, { token, periodAmount, periodDuration, startDate }) => [
       ...acc,
       pad(token, { size: 20 }),

--- a/packages/delegator-e2e/test/caveats/caveatUtils.test.ts
+++ b/packages/delegator-e2e/test/caveats/caveatUtils.test.ts
@@ -623,16 +623,18 @@ describe('MultiTokenPeriodEnforcer', () => {
       delegator: aliceSmartAccount.address,
       authority: ROOT_AUTHORITY as Address,
       caveats: createCaveatBuilder(aliceSmartAccount.environment)
-        .addCaveat('multiTokenPeriod', [
-          {
-            token: erc20TokenAddress,
-            periodAmount,
-            periodDuration,
-            startDate: currentTime,
-          },
-        ])
+        .addCaveat('multiTokenPeriod', {
+          tokenConfigs: [
+            {
+              token: erc20TokenAddress,
+              periodAmount,
+              periodDuration,
+              startDate: currentTime,
+            },
+          ],
+        })
         .build(),
-      salt: '0x1' as Hex,
+      salt: '0x1' as const,
       signature: '0x1',
     };
 
@@ -719,14 +721,16 @@ describe('MultiTokenPeriodEnforcer', () => {
       delegator: aliceSmartAccount.address,
       authority: ROOT_AUTHORITY as Address,
       caveats: createCaveatBuilder(aliceSmartAccount.environment)
-        .addCaveat('multiTokenPeriod', [
-          {
-            token: erc20TokenAddress,
-            periodAmount,
-            periodDuration,
-            startDate: futureStartDate,
-          },
-        ])
+        .addCaveat('multiTokenPeriod', {
+          tokenConfigs: [
+            {
+              token: erc20TokenAddress,
+              periodAmount,
+              periodDuration,
+              startDate: futureStartDate,
+            },
+          ],
+        } as any)
         .build(),
       salt: '0x1' as Hex,
       signature: '0x1',
@@ -805,14 +809,16 @@ describe('MultiTokenPeriodEnforcer', () => {
       delegator: aliceSmartAccount.address,
       authority: ROOT_AUTHORITY as Address,
       caveats: createCaveatBuilder(aliceSmartAccount.environment)
-        .addCaveat('multiTokenPeriod', [
-          {
-            token: erc20TokenAddress,
-            periodAmount,
-            periodDuration,
-            startDate,
-          },
-        ])
+        .addCaveat('multiTokenPeriod', {
+          tokenConfigs: [
+            {
+              token: erc20TokenAddress,
+              periodAmount,
+              periodDuration,
+              startDate,
+            },
+          ],
+        } as any)
         .build(),
       salt: '0x1' as Hex,
       signature: '0x1',
@@ -1501,14 +1507,16 @@ describe('Individual action functions vs client extension methods', () => {
       delegator: aliceSmartAccount.address,
       authority: ROOT_AUTHORITY as Address,
       caveats: createCaveatBuilder(aliceSmartAccount.environment)
-        .addCaveat('multiTokenPeriod', [
-          {
-            token: erc20TokenAddress,
-            periodAmount,
-            periodDuration,
-            startDate: currentTime,
-          },
-        ])
+        .addCaveat('multiTokenPeriod', {
+          tokenConfigs: [
+            {
+              token: erc20TokenAddress,
+              periodAmount,
+              periodDuration,
+              startDate: currentTime,
+            },
+          ],
+        } as any)
         .build(),
       salt: '0x1' as Hex,
       signature: '0x1',

--- a/packages/delegator-e2e/test/caveats/multiTokenPeriod.test.ts
+++ b/packages/delegator-e2e/test/caveats/multiTokenPeriod.test.ts
@@ -127,7 +127,7 @@ const runTest_expectSuccess = async (
     authority: ROOT_AUTHORITY,
     salt: '0x0',
     caveats: createCaveatBuilder(environment)
-      .addCaveat('multiTokenPeriod', configs)
+      .addCaveat('multiTokenPeriod', { tokenConfigs: configs })
       .build(),
     signature: '0x',
   };
@@ -215,7 +215,7 @@ const runTest_expectFailure = async (
     authority: ROOT_AUTHORITY,
     salt: '0x0',
     caveats: createCaveatBuilder(environment)
-      .addCaveat('multiTokenPeriod', configs)
+      .addCaveat('multiTokenPeriod', { tokenConfigs: configs })
       .build(),
     signature: '0x',
   };


### PR DESCRIPTION
`MultiTokenPeriodBuilder` accepts an array as it's config. This is problematic when applied to the declarative API, which expects to be able to squash the config object onto the declarative config.

## 📝 Description

Previously the builder would accept an array `builder.addCaveat("multiTokenPeriod", [ { token, ... } ])`.

With this change, the builder now accepts an object with `tokenConfigs`. `builder.addCaveat("multiTokenPeriod", { tokenConfigs: [ { token, ... } ] })`.

Although it doesn't necessarily make sense to use this caveat to attenuate any of the existing scopes, it's important to have consistency across all caveat types.