### PR TITLE
Export DelegatedCall type in experimental namespace

### DIFF
--- a/packages/delegation-toolkit/src/experimental/index.ts
+++ b/packages/delegation-toolkit/src/experimental/index.ts
@@ -15,6 +15,8 @@ import type {
   RequestExecutionPermissionsParameters,
 } from './erc7715RequestExecutionPermissionsAction';
 
+export type { DelegatedCall } from './erc7710RedeemDelegationAction';
+
 export {
   erc7715RequestExecutionPermissionsAction as requestExecutionPermissions,
   type MetaMaskExtensionClient,


### PR DESCRIPTION
## 📝 Description

Export `DelegatedCall` type in experimental namespace, to allow consumers to type params when redeeming a delegation with the experimental `sendUserOperationWithDelegation` methods.

## 🔄 What Changed?

Export added to experimental namespace.

## 🧪 How to Test?

```
import type { DelegatedCall } from '@metamask/delegation-toolkit/experimental';
```

Then use this type when declaring the `call` parameter to `sendUserOperationWithDelegation`.

Note: this isn't impacting `sendTransactionWithDelegation` because the delegation details are added to the top level `SendTransactionWtihDelegationParameters` type which, although not exported directly, does not require an additional "calls" parameter.


## ⚠️ Breaking Changes

List any breaking changes:

- [x] No breaking changes
- [ ] Breaking changes (describe below):

## 📋 Checklist

Check off completed items:

- [ ] Code follows the project's coding standards
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] Changelog updated (if needed)
- [ ] All CI checks pass

## 🔗 Related Issues

Link to related issues:
Closes #
Related to #

## 📚 Additional Notes

Any additional information, concerns, or context:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expose `DelegatedCall` type from `experimental/index.ts` for typing calls in `sendUserOperationWithDelegation`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc409b70efa9282d94b70840c660d72e5591475c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->